### PR TITLE
feat(iterables): add accus to all iter blocks

### DIFF
--- a/src/lang/iterable/common.fnk
+++ b/src/lang/iterable/common.fnk
@@ -1,4 +1,7 @@
-{consts, yields} = import '../../js/types'
+{length} = import '@fink/std-lib/iter'
+
+{consts, yields, lets, assign} = import '../../js/types'
+{block_statement} = import '../block'
 
 
 transform_init = fn left, right, {transform}:
@@ -13,6 +16,7 @@ transform_init = fn left, right, {transform}:
   consts item_init.left, item_init.right
 
 
+
 yield_expr = fn result, expr, {transform}:
   [yield_value, is_spread] = match expr:
     {type: 'spread'}: [expr.right, true]
@@ -23,3 +27,72 @@ yield_expr = fn result, expr, {transform}:
     yields
       result
       is_spread
+
+
+
+get_accs = fn node, last_expr, ctx:
+  {unique_ident, transform} = ctx
+  [, acc_arg] = node.args
+
+  match node.args:
+    2 == length ?:
+      acc = unique_ident 'accu'
+      acc_init = lets acc, transform acc_arg.right
+
+      acc_assign = transform_init acc_arg.left, acc, ctx
+
+      [result_expr, acc_expr] = last_expr.exprs
+      next_acc_assign = assign acc, transform acc_expr
+
+      [[acc_init], [acc_assign], result_expr, [next_acc_assign], acc]
+
+    else:
+      [[], [], last_expr, []]
+
+
+get_item = fn node, ctx:
+  {unique_ident} = ctx
+
+  [item_arg] = node.args
+  item = unique_ident 'item'
+
+  match item_arg:
+    {type: 'empty'}:
+      [item, []]
+    else:
+      item_init = transform_init item_arg, item, ctx
+      [item, [item_init]]
+
+
+
+get_iter_helpers = fn node, ctx:
+  {unique_ident, transform} = ctx
+
+  [item, item_init] = get_item node, ctx
+
+  # TODO move next line into get_accs?
+  [...exprs, last_expr] = node.exprs
+  [acc_init, acc_assign, result_expr1, next_accu, accu] = get_accs node, last_expr, ctx
+
+  items = unique_ident 'items'
+  result = unique_ident 'result'
+
+  item_acc_assign = [...item_init, ...acc_assign]
+
+  [result_expr, result_is_spread] = match result_expr1:
+    {type: 'spread'}: [result_expr1.right, true]
+    else: [result_expr1, false]
+
+  expressions = pipe exprs:
+    map expr: block_statement expr, ctx
+    [...?, consts result, transform result_expr]
+
+  dict:
+    accu, acc_init
+    item, items
+    item_acc_assign
+    expressions
+    result, result_is_spread
+    next_accu
+
+

--- a/src/lang/iterable/filter.fnk
+++ b/src/lang/iterable/filter.fnk
@@ -1,32 +1,31 @@
 {ifStatement} = import'@babel/types'
 
-{generator, for_of, yields, consts} = import '../../js/types'
+{generator, for_of, yields} = import '../../js/types'
 
-{block_statement} = import '../block'
-{transform_init} = import './common'
+{get_iter_helpers} = import './common'
 
 
 transform_filter = fn node, ctx:
-  {transform, unique_ident} = ctx
+  {
+    acc_init
+    item, items
+    item_acc_assign
+    expressions
+    result
+    next_accu
+  } = get_iter_helpers node, ctx
 
-  item = unique_ident 'item'
-  [item_val] = node.args
-  item_init = transform_init item_val, item, ctx
-
-  items = unique_ident 'items'
-  result = unique_ident 'result'
-
-  [...expressions, last_expr] = node.exprs
 
   generator 'filter', [items],
+    ...acc_init
+
     for_of [item, items],
-      item_init
+      ...item_acc_assign
 
-      ...pipe expressions:
-        map expr: block_statement expr, ctx
-
-      consts result, transform last_expr
+      ...expressions
 
       ifStatement
         result
         yields item
+
+      ...next_accu

--- a/src/lang/iterable/filter.test.fnk
+++ b/src/lang/iterable/filter.test.fnk
@@ -18,3 +18,26 @@ describe 'filter', fn:
       `
       to_match_snapshot
 
+
+  it 'compiles with accu', fn:
+    expect
+      fink2js `
+        filter item, cntr=0:
+          (item < 1 and cntr % 2 == 0, cntr + 1)
+      `
+      to_match_snapshot
+
+    expect
+      fink2js `
+        filter _, is_even=false:
+          (is_even, not is_even)
+      `
+      to_match_snapshot
+
+    expect
+      fink2js `
+        filter , is_even=false:
+          (is_even, not is_even)
+      `
+      to_match_snapshot
+

--- a/src/lang/iterable/filter.test.fnk.snap
+++ b/src/lang/iterable/filter.test.fnk.snap
@@ -33,3 +33,43 @@ exports[`filter compiles 1`] = `
   }
 });"
 `;
+
+exports[`filter compiles with accu 1`] = `
+"(function* filter(ˆitems_3) {
+  let ˆaccu_2 = 0;
+
+  for (const ˆitem_1 of ˆitems_3) {
+    const item = ˆitem_1;
+    const cntr = ˆaccu_2;
+    const ˆresult_4 = item < 1 && cntr % 2 === 0;
+    if (ˆresult_4) yield ˆitem_1;
+    ˆaccu_2 = cntr + 1;
+  }
+});"
+`;
+
+exports[`filter compiles with accu 2`] = `
+"(function* filter(ˆitems_3) {
+  let ˆaccu_2 = false;
+
+  for (const ˆitem_1 of ˆitems_3) {
+    const is_even = ˆaccu_2;
+    const ˆresult_4 = is_even;
+    if (ˆresult_4) yield ˆitem_1;
+    ˆaccu_2 = !is_even;
+  }
+});"
+`;
+
+exports[`filter compiles with accu 3`] = `
+"(function* filter(ˆitems_3) {
+  let ˆaccu_2 = false;
+
+  for (const ˆitem_1 of ˆitems_3) {
+    const is_even = ˆaccu_2;
+    const ˆresult_4 = is_even;
+    if (ˆresult_4) yield ˆitem_1;
+    ˆaccu_2 = !is_even;
+  }
+});"
+`;

--- a/src/lang/iterable/find.fnk
+++ b/src/lang/iterable/find.fnk
@@ -1,36 +1,34 @@
 {returnStatement, ifStatement} = import'@babel/types'
 
-{for_of, func, consts, undef} = import '../../js/types'
+{func, for_of, undef} = import '../../js/types'
 
-{block_statement} = import '../block'
-{transform_init} = import './common'
+{get_iter_helpers} = import './common'
 
 
 transform_find = fn node, ctx:
-  {transform, unique_ident} = ctx
+  {
+    acc_init
+    item, items
+    item_acc_assign
+    expressions
+    result
+    next_accu
+  } = get_iter_helpers node, ctx
 
-  item = unique_ident 'item'
-  [item_val] = node.args;
-  item_init = transform_init item_val, item, ctx
-
-  items = unique_ident 'items'
-  found = unique_ident 'found'
-
-  [...expressions, last_expr] = node.exprs
 
   func [items],
+    ...acc_init
 
     for_of [item, items],
-      item_init
+      ...item_acc_assign
 
-      ...pipe expressions:
-        map expr: block_statement expr, ctx
-
-      consts found, transform last_expr
+      ...expressions
 
       ifStatement
-        found
+        result
         returnStatement item
+
+      ...next_accu
 
     undef ()
 

--- a/src/lang/iterable/find.test.fnk
+++ b/src/lang/iterable/find.test.fnk
@@ -30,5 +30,11 @@ describe 'find', fn:
       to_match_snapshot
 
 
-
+  it 'compiles find with accu', fn:
+    expect
+      fink2js `
+        find item, is_even_elem=false:
+          (item > 123 and is_even_elem, not is_even_elem)
+      `
+      to_match_snapshot
 

--- a/src/lang/iterable/find.test.fnk.snap
+++ b/src/lang/iterable/find.test.fnk.snap
@@ -29,9 +29,9 @@ exports[`find compiles complex find 1`] = `
       }
     }
 
-    const ˆfound_3 = _do_result;
+    const ˆresult_3 = _do_result;
     _do_result = undefined;
-    if (ˆfound_3) return ˆitem_1;
+    if (ˆresult_3) return ˆitem_1;
   }
 
   return undefined;
@@ -41,8 +41,8 @@ exports[`find compiles complex find 1`] = `
   for (const ˆitem_7 of ˆitems_8) {
     const [foo, ...bar] = ˆitem_7;
     const foo_alone = foo && 0 === length(bar);
-    const ˆfound_9 = foo_alone;
-    if (ˆfound_9) return ˆitem_7;
+    const ˆresult_9 = foo_alone;
+    if (ˆresult_9) return ˆitem_7;
   }
 
   return undefined;
@@ -58,8 +58,24 @@ exports[`find compiles complex find 1`] = `
     }
     const [foo, [bar]] = _do_result2;
     _do_result2 = undefined;
-    const ˆfound_13 = bar && 0 === length(foo);
-    if (ˆfound_13) return ˆitem_10;
+    const ˆresult_13 = bar && 0 === length(foo);
+    if (ˆresult_13) return ˆitem_10;
+  }
+
+  return undefined;
+};"
+`;
+
+exports[`find compiles find with accu 1`] = `
+"ˆitems_3 => {
+  let ˆaccu_2 = false;
+
+  for (const ˆitem_1 of ˆitems_3) {
+    const item = ˆitem_1;
+    const is_even_elem = ˆaccu_2;
+    const ˆresult_4 = item > 123 && is_even_elem;
+    if (ˆresult_4) return ˆitem_1;
+    ˆaccu_2 = !is_even_elem;
   }
 
   return undefined;
@@ -70,8 +86,8 @@ exports[`find compiles simple find 1`] = `
 "ˆitems_2 => {
   for (const ˆitem_1 of ˆitems_2) {
     const item = ˆitem_1;
-    const ˆfound_3 = item > 3;
-    if (ˆfound_3) return ˆitem_1;
+    const ˆresult_3 = item > 3;
+    if (ˆresult_3) return ˆitem_1;
   }
 
   return undefined;

--- a/src/lang/iterable/fold.fnk
+++ b/src/lang/iterable/fold.fnk
@@ -11,7 +11,7 @@ transform_fold = fn node, ctx:
   item = unique_ident 'item'
   item_init = transform_init item_arg, item, ctx
 
-  acc = unique_ident 'acc'
+  acc = unique_ident 'accu'
   acc_assign = transform_init acc_arg.left, acc, ctx
 
   items = unique_ident 'items'

--- a/src/lang/iterable/fold.test.fnk.snap
+++ b/src/lang/iterable/fold.test.fnk.snap
@@ -2,70 +2,70 @@
 
 exports[`fold compiles 1`] = `
 "ˆitems_3 => {
-  let ˆacc_2 = 0;
+  let ˆaccu_2 = 0;
 
   for (const ˆitem_1 of ˆitems_3) {
-    const acc = ˆacc_2;
+    const acc = ˆaccu_2;
     const item = ˆitem_1;
     const ni = item + acc;
-    ˆacc_2 = item * acc;
+    ˆaccu_2 = item * acc;
   }
 
-  return ˆacc_2;
+  return ˆaccu_2;
 };"
 `;
 
 exports[`fold destructuring accu 1`] = `
 "ˆitems_3 => {
-  let ˆacc_2 = [];
+  let ˆaccu_2 = [];
 
   for (const ˆitem_1 of ˆitems_3) {
-    const [foo, ...bar] = ˆacc_2;
+    const [foo, ...bar] = ˆaccu_2;
     const item = ˆitem_1;
-    ˆacc_2 = [item, bar, foo];
+    ˆaccu_2 = [item, bar, foo];
   }
 
-  return ˆacc_2;
+  return ˆaccu_2;
 };
 
 ˆitems_7 => {
-  let ˆacc_5 = [];
+  let ˆaccu_5 = [];
 
   for (const ˆitem_4 of ˆitems_7) {
     let _do_result;
 
     {
-      const [...ˆitems_6] = ˆacc_5;
+      const [...ˆitems_6] = ˆaccu_5;
       _do_result = [ˆitems_6.slice(0, -1), ˆitems_6.slice(-1)];
     }
     const [foo, [bar]] = _do_result;
     _do_result = undefined;
     const item = ˆitem_4;
-    ˆacc_5 = [item, bar, foo];
+    ˆaccu_5 = [item, bar, foo];
   }
 
-  return ˆacc_5;
+  return ˆaccu_5;
 };"
 `;
 
 exports[`fold destructuring item 1`] = `
 "ˆitems_3 => {
-  let ˆacc_2 = [];
+  let ˆaccu_2 = [];
 
   for (const ˆitem_1 of ˆitems_3) {
-    const acc = ˆacc_2;
+    const acc = ˆaccu_2;
     const [foo, ...bar] = ˆitem_1;
-    ˆacc_2 = [[foo, bar], ...acc];
+    ˆaccu_2 = [[foo, bar], ...acc];
   }
 
-  return ˆacc_2;
+  return ˆaccu_2;
 };
 
 ˆitems_7 => {
-  let ˆacc_6 = [];
+  let ˆaccu_6 = [];
 
   for (const ˆitem_4 of ˆitems_7) {
-    const acc = ˆacc_6;
+    const acc = ˆaccu_6;
 
     let _do_result;
 
@@ -75,9 +75,9 @@ exports[`fold destructuring item 1`] = `
     }
     const [foo, [bar]] = _do_result;
     _do_result = undefined;
-    ˆacc_6 = [[foo, bar], ...acc];
+    ˆaccu_6 = [[foo, bar], ...acc];
   }
 
-  return ˆacc_6;
+  return ˆaccu_6;
 };"
 `;

--- a/src/lang/iterable/map.fnk
+++ b/src/lang/iterable/map.fnk
@@ -1,54 +1,29 @@
-{length} = import '@fink/std-lib/iter'
+{generator, for_of, yields} = import '../../js/types'
 
-{generator, for_of, lets, assign} = import '../../js/types'
+{get_iter_helpers} = import './common'
 
-{block_statement} = import '../block'
-{transform_init, yield_expr} = import './common'
-
-
-get_accs = fn node, last_expr, ctx:
-  {unique_ident, transform} = ctx
-  [, acc_arg] = node.args
-
-  match node.args:
-    2 == length ?:
-      acc = unique_ident 'accu'
-      acc_init = lets acc, transform acc_arg.right
-
-      acc_assign = transform_init acc_arg.left, acc, ctx
-
-      [result_expr, acc_expr] = last_expr.exprs
-      next_acc_assign = assign acc, transform acc_expr
-
-      [[acc_init], [acc_assign], result_expr, [next_acc_assign]]
-
-    else:
-      [[], [], last_expr, []]
 
 
 transform_map = fn node, ctx:
-  {unique_ident} = ctx
-
-  [item_arg] = node.args
-  item = unique_ident 'item'
-  item_init = transform_init item_arg, item, ctx
-
-  [...expressions, last_expr] = node.exprs
-
-  [acc_init, acc_assign, result_expr, next_accu] = get_accs node, last_expr, ctx
-
-  items = unique_ident 'items'
-  result = unique_ident 'result'
+  {
+    acc_init
+    item, items
+    item_acc_assign
+    expressions
+    result, result_is_spread
+    next_accu
+  } = get_iter_helpers node, ctx
 
   generator 'map', [items],
     ...acc_init
 
     for_of [item, items],
-      item_init
-      ...acc_assign
+      ...item_acc_assign
 
-      ...pipe expressions:
-        map expr: block_statement expr, ctx
+      ...expressions
 
-      ...yield_expr result, result_expr, ctx
+      yields
+        result
+        result_is_spread
+
       ...next_accu

--- a/src/lang/iterable/map.test.fnk
+++ b/src/lang/iterable/map.test.fnk
@@ -72,6 +72,13 @@ describe 'map', fn:
       `
       to_match_snapshot
 
+    expect
+      fink2js `
+        map {foo}, acc=0:
+          (...[acc, foo], acc+1)
+      `
+      to_match_snapshot
+
 
   it 'compiles destructuring', fn:
     expect

--- a/src/lang/iterable/map.test.fnk.snap
+++ b/src/lang/iterable/map.test.fnk.snap
@@ -104,6 +104,22 @@ exports[`map compiles with acc 1`] = `
 });"
 `;
 
+exports[`map compiles with acc 2`] = `
+"(function* map(ˆitems_3) {
+  let ˆaccu_2 = 0;
+
+  for (const ˆitem_1 of ˆitems_3) {
+    const {
+      \\"foo\\": foo
+    } = ˆitem_1;
+    const acc = ˆaccu_2;
+    const ˆresult_4 = [acc, foo];
+    yield* ˆresult_4;
+    ˆaccu_2 = acc + 1;
+  }
+});"
+`;
+
 exports[`map compiles with foo 1`] = `
 "(function* map(ˆitems_2) {
   for (const ˆitem_1 of ˆitems_2) {

--- a/src/lang/iterable/until.fnk
+++ b/src/lang/iterable/until.fnk
@@ -1,39 +1,37 @@
 {returnStatement, ifStatement} = import'@babel/types'
 
-{generator, for_of, yields, consts, eq, true_} = import '../../js/types'
+{generator, for_of, yields, eq, true_} = import '../../js/types'
 
-{block_statement} = import '../block'
-{transform_init} = import './common'
+{get_iter_helpers} = import './common'
 
 
 
 transform_until = fn node, ctx:
-  {transform, unique_ident} = ctx
-
-  item = unique_ident 'item'
-  [item_val] = node.args;
-  item_init = transform_init item_val, item, ctx
-
-  items = unique_ident 'items'
-  result = unique_ident 'result'
-
-  [...expressions, last_expr] = node.exprs
+  {
+    acc_init
+    item, items
+    item_acc_assign
+    expressions
+    result
+    next_accu
+  } = get_iter_helpers node, ctx
 
   generator 'filter_until', [items],
+    ...acc_init
+
     for_of [item, items],
       # should we yield before executing the condition?
       yields item
 
-      item_init
+      ...item_acc_assign
 
-      ...pipe expressions:
-        map expr: block_statement expr, ctx
-
-      consts result, transform last_expr
+      ...expressions
 
       ifStatement
         eq result, true_ ()
         returnStatement ()
+
+      ...next_accu
 
 
 

--- a/src/lang/iterable/until.test.fnk
+++ b/src/lang/iterable/until.test.fnk
@@ -12,6 +12,18 @@ describe 'while', fn:
       to_match_snapshot
 
 
+  it 'compiles with accu', fn:
+    expect
+      fink2js `
+        until _, cntr=0:
+          (cntr > 2, cntr + 1)
+
+        until , cntr=0:
+          (cntr > 2, cntr + 1)
+      `
+      to_match_snapshot
+
+
   it 'compiles destructuring', fn:
     expect
       fink2js `

--- a/src/lang/iterable/until.test.fnk.snap
+++ b/src/lang/iterable/until.test.fnk.snap
@@ -39,3 +39,29 @@ exports[`while compiles destructuring 1`] = `
   }
 });"
 `;
+
+exports[`while compiles with accu 1`] = `
+"(function* filter_until(ˆitems_3) {
+  let ˆaccu_2 = 0;
+
+  for (const ˆitem_1 of ˆitems_3) {
+    yield ˆitem_1;
+    const cntr = ˆaccu_2;
+    const ˆresult_4 = cntr > 2;
+    if (ˆresult_4 === true) return;
+    ˆaccu_2 = cntr + 1;
+  }
+});
+
+(function* filter_until(ˆitems_7) {
+  let ˆaccu_6 = 0;
+
+  for (const ˆitem_5 of ˆitems_7) {
+    yield ˆitem_5;
+    const cntr = ˆaccu_6;
+    const ˆresult_8 = cntr > 2;
+    if (ˆresult_8 === true) return;
+    ˆaccu_6 = cntr + 1;
+  }
+});"
+`;

--- a/src/lang/iterable/while.fnk
+++ b/src/lang/iterable/while.fnk
@@ -1,32 +1,28 @@
 {returnStatement, ifStatement} = import'@babel/types'
 
-{generator, for_of, yields, consts, neq, true_} = import '../../js/types'
+{generator, for_of, yields, neq, true_} = import '../../js/types'
 
-{block_statement} = import '../block'
-{transform_init} = import './common'
+{get_iter_helpers} = import './common'
 
 
 
 transform_while = fn node, ctx:
-  {transform, unique_ident} = ctx
-
-  item = unique_ident 'item'
-  [item_val] = node.args;
-  item_init = transform_init item_val, item, ctx
-
-  items = unique_ident 'items'
-  result = unique_ident 'result'
-
-  [...expressions, last_expr] = node.exprs
+  {
+    acc_init
+    item, items
+    item_acc_assign
+    expressions
+    result
+    next_accu
+  } = get_iter_helpers node, ctx
 
   generator 'filter_while', [items],
+    ...acc_init
+
     for_of [item, items],
-      item_init
+      ...item_acc_assign
 
-      ...pipe expressions:
-        map expr: block_statement expr, ctx
-
-      consts result, transform last_expr
+      ...expressions
 
       ifStatement
         neq result, true_ ()
@@ -34,3 +30,4 @@ transform_while = fn node, ctx:
 
       yields item
 
+      ...next_accu

--- a/src/lang/iterable/while.test.fnk
+++ b/src/lang/iterable/while.test.fnk
@@ -12,6 +12,21 @@ describe 'while', fn:
       to_match_snapshot
 
 
+  it 'compiles with accu', fn:
+    expect
+      fink2js `
+        while _, cntr=0:
+          (cntr < 2, cntr + 1)
+
+        while , cntr=0:
+          (cntr < 2, cntr + 1)
+
+        while item, cntr=0:
+          (item and cntr < 2, cntr + 1)
+      `
+      to_match_snapshot
+
+
   it 'compiles destructuring', fn:
     expect
       fink2js `

--- a/src/lang/iterable/while.test.fnk.snap
+++ b/src/lang/iterable/while.test.fnk.snap
@@ -38,3 +38,42 @@ exports[`while compiles destructuring 1`] = `
   }
 });"
 `;
+
+exports[`while compiles with accu 1`] = `
+"(function* filter_while(ˆitems_3) {
+  let ˆaccu_2 = 0;
+
+  for (const ˆitem_1 of ˆitems_3) {
+    const cntr = ˆaccu_2;
+    const ˆresult_4 = cntr < 2;
+    if (ˆresult_4 !== true) return;
+    yield ˆitem_1;
+    ˆaccu_2 = cntr + 1;
+  }
+});
+
+(function* filter_while(ˆitems_7) {
+  let ˆaccu_6 = 0;
+
+  for (const ˆitem_5 of ˆitems_7) {
+    const cntr = ˆaccu_6;
+    const ˆresult_8 = cntr < 2;
+    if (ˆresult_8 !== true) return;
+    yield ˆitem_5;
+    ˆaccu_6 = cntr + 1;
+  }
+});
+
+(function* filter_while(ˆitems_11) {
+  let ˆaccu_10 = 0;
+
+  for (const ˆitem_9 of ˆitems_11) {
+    const item = ˆitem_9;
+    const cntr = ˆaccu_10;
+    const ˆresult_12 = item && cntr < 2;
+    if (ˆresult_12 !== true) return;
+    yield ˆitem_9;
+    ˆaccu_10 = cntr + 1;
+  }
+});"
+`;


### PR DESCRIPTION
All iter blocks (`map`, `filter`, `while`, `until`, `find`) support accus as 2nd arg, and results in the form `(result, new_accu_value)` to update the accu for the next loop.