### PR TITLE
feat(import): improve file ext handling.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -456,9 +456,9 @@
       }
     },
     "@fink/loxia": {
-      "version": "12.2.2",
-      "resolved": "https://registry.npmjs.org/@fink/loxia/-/loxia-12.2.2.tgz",
-      "integrity": "sha512-s3J2HTTcE/Afz+UpR2/WhkJZTvoGmQtE98eSPGfK22IGNdK+OIwrYVvO7LhV0Gni4jy0uFvb9q1hMh3obsPy3Q==",
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/@fink/loxia/-/loxia-12.4.0.tgz",
+      "integrity": "sha512-K7LOR/oHFpse2IbsALdWQVW2oF4fqJfmr+3CnhBwbrea3I4Zn5hg355YEPjCH7O3Y8dQwPRe2JAa5I6xZarqUw==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.10.5",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@fink/cli": "^6.2.1",
     "@fink/jest": "^5.4.0",
     "@fink/larix": "^12.3.0",
-    "@fink/loxia": "^12.2.2",
+    "@fink/loxia": "^12.4.0",
     "commitizen": "^4.1.2",
     "cz-conventional-changelog": "^3.1.0",
     "jest-cli": "^26.1.0",

--- a/src/index.fnk
+++ b/src/index.fnk
@@ -9,8 +9,9 @@
 {module_transforms} = import './js/module'
 
 
+
 transform = fn node, code, filename, options:
-  ast = transform_ast node, code, filename
+  ast = transform_ast node, code, filename, options
 
   extras = match options:
     {module_type: 'cjs'}: module_transforms
@@ -25,19 +26,15 @@ transform = fn node, code, filename, options:
   ast
 
 
-babel_generate = fn ast, filename, source, options:
-  {use_babel_conf, module_type: _, source_maps, ...rest_opts} = options
 
-  conf_opts = match true:
-    use_babel_conf: {}
-    else: {babelrc: false, configFile: false}
+babel_generate = fn ast, filename, source, options:
+  {babel={babelrc: false, configFile: false}, source_maps} = options
 
   babel_opts = dict:
     filename
     sourceFileName: filename
     sourceMaps: source_maps
-    ...conf_opts
-    ...rest_opts
+    ...babel
 
   [error, result] = try:
     {code, map: source_map} = transformFromAstSync ast, source, babel_opts
@@ -48,6 +45,7 @@ babel_generate = fn ast, filename, source, options:
       result
     else:
       {code: '', source_map: '', errors: [error]}
+
 
 
 generate = fn ast, filename, source, options={}:

--- a/src/index.test.fnk
+++ b/src/index.test.fnk
@@ -70,7 +70,7 @@ describe 'errors', fn:
   it 'errors with bad babel options', fn:
     {errors: [{message}]} = fink2js
       'foo = bar'
-      {use_babel_conf: true, foobar: 'spam'}
+      {babel: {foobar: 'spam'}}
 
     expect
       slice message, 0, 24

--- a/src/lang/index.fnk
+++ b/src/lang/index.fnk
@@ -115,9 +115,9 @@ init_ctx = fn code, filename:
     add_transformers
 
 
-transform_ast = fn expr, code, filename:
+transform_ast = fn expr, code, filename, options:
   ctx = init_ctx code, filename
-  js_ast = transform_expr expr, ctx
+  js_ast = transform_expr expr, {...ctx, options}
 
   match js_ast:
     {error: {}}:

--- a/src/lang/module/import.fnk
+++ b/src/lang/module/import.fnk
@@ -1,25 +1,36 @@
 {callExpression, Import: async_import} = import '@babel/types'
-{ends_with, slice} = import '@fink/std-lib/str'
+{ends_with, starts_with, slice, is_str} = import '@fink/std-lib/str'
 
 
 
-resolve_ext = fn import_url:
+resolve_ext = fn import_url, options:
   match import_url:
-    ends_with ?, '.fnk':
-      '${slice import_url, 0, -4}.js'
-    else:
+    not ends_with ?, '.fnk':
       import_url
 
+    starts_with ?, '.':
+      ext = match options:
+        {import: {ext: {rel: is_str ?}}}: options.import.ext.rel
+        else: '.js'
+      '${slice import_url, 0, -4}${ext}'
+
+    else:
+      ext = match options:
+        {import: {ext: {abs: is_str ?}}}: options.import.ext.abs
+        else: '.js'
+      '${slice import_url, 0, -4}${ext}'
 
 
-transform_import = fn node, {transform}:
+
+transform_import = fn node, {transform, options}:
+
   right = match node.right:
     {type: 'string', exprs: [..., {type: 'string:text'}]}:
       [...exprs, url] = node.right.exprs
 
       transform dict:
         ...node.right
-        exprs: [...exprs, {...url, value: resolve_ext url.value}]
+        exprs: [...exprs, {...url, value: resolve_ext url.value, options}]
     else:
       transform node.right
 

--- a/src/lang/module/import.test.fnk
+++ b/src/lang/module/import.test.fnk
@@ -1,0 +1,66 @@
+{fink2js} = import '../../testing'
+{describe, it, expect, to_match_snapshot} = import '@fink/jest'
+
+
+describe 'import', fn:
+  it 'imports exported values', fn:
+    expect
+      fink2js "
+        {bar} = import './spam.fnk'
+        {foo: spam} = import './shrub.fnk'
+      "
+      to_match_snapshot
+
+
+  it 'imports dynamically with static URL', fn:
+    expect
+      fink2js "
+        ni = await import './shrub.fnk'
+      "
+      to_match_snapshot
+
+
+  it 'imports with dynamic URLs', fn:
+    expect
+      fink2js "
+        foo = bar + spam
+        shrub = await import foo
+        ni = await import '\${foo}'
+        na = await import './\${foo}.fnk'
+      "
+      to_match_snapshot
+
+
+  it 'imports without transforming ext', fn:
+    expect
+      fink2js
+        "
+          #
+          {is_str} = import '@fink/std-lib/str.fnk'
+          {bar} = import './spam.fnk'
+          {foo: spam} = await import './shrub.fnk'
+          na = await import './\${foo}.fnk'
+          import './foo.fnk'
+          ni = import '../ni.fnk'
+        "
+        {import: {ext: {rel: '.fnk', abs: '.js'}}}
+      to_match_snapshot
+
+
+  it 'imports module', fn:
+
+    expect
+      fink2js "
+        import 'shrub'
+        import '@fink/foo/bar.fnk'
+      "
+      to_match_snapshot
+
+
+  it 'imports default export', fn:
+    expect
+      fink2js "
+        foo = import './foo.fnk'
+      "
+      to_match_snapshot
+

--- a/src/lang/module/import.test.fnk.snap
+++ b/src/lang/module/import.test.fnk.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`import imports default export 1`] = `"import foo from \\"./foo.js\\";"`;
+
+exports[`import imports dynamically with static URL 1`] = `"export const ni = await import(\`./shrub.js\`);"`;
+
+exports[`import imports exported values 1`] = `
+"import { bar } from \\"./spam.js\\";
+import { foo as spam } from \\"./shrub.js\\";"
+`;
+
+exports[`import imports module 1`] = `
+"import \\"shrub\\";
+import \\"@fink/foo/bar.js\\";"
+`;
+
+exports[`import imports with dynamic URLs 1`] = `
+"export const foo = bar + spam;
+export const shrub = await import(foo);
+export const ni = await import(\`\${foo}\`);
+export const na = await import(\`./\${foo}.js\`);"
+`;
+
+exports[`import imports without transforming ext 1`] = `
+"//
+import { is_str } from \\"@fink/std-lib/str.js\\";
+import { bar } from \\"./spam.fnk\\";
+const {
+  \\"foo\\": spam
+} = await import(\`./shrub.fnk\`);
+export const na = await import(\`./\${foo}.fnk\`);
+import \\"./foo.fnk\\";
+import ni from \\"../ni.fnk\\";"
+`;

--- a/src/lang/module/index.fnk
+++ b/src/lang/module/index.fnk
@@ -26,7 +26,7 @@ get_shebang = fn expr:
 
 
 
-transform_import = fn node, {transform}:
+transform_import = fn node, {transform, options}:
   [...imports] = match node.left:
     {type: 'ident'}:
       [importDefaultSpecifier transform node.left]
@@ -49,7 +49,7 @@ transform_import = fn node, {transform}:
   importDeclaration
     imports
     wrap_with_comment_loc
-      stringLiteral resolve_ext url.value
+      stringLiteral resolve_ext url.value, options
       node.right.right
 
 
@@ -64,7 +64,7 @@ transform_module = fn node, ctx:
         {op: 'import'}:
           {right: {exprs: [url]}} = expr
           wrap_with_comment_loc
-            importDeclaration [], stringLiteral resolve_ext url.value
+            importDeclaration [], stringLiteral resolve_ext url.value, ctx.options
             expr
 
         {right: {op: 'import'}}:

--- a/src/lang/module/index.test.fnk
+++ b/src/lang/module/index.test.fnk
@@ -11,28 +11,9 @@ describe 'module', fn:
 
         # leading comment
 
-        # static imports
-        import 'shrub'
-        import '@fink/foo/bar.fnk'
+        # expr comment
+        foo = 1234
 
-        # default import
-        foo = import './foo.fnk'
-
-        # import exported values
-        {bar} = import './spam.fnk'
-        {foo: spam} = import './shrub.fnk'
-
-        # dynamic imports with static URL
-        ni = await import './shrub.fnk'
-
-        # dynamic imports with dynamic URLs
-        shrub = foo + bar
-        ni2 = await import shrub
-        ni3 = await import '\${shrub}'
-        ni4 = await import './\${shrub}.fnk'
         # trailing comment
       "
       to_match_snapshot
-
-
-

--- a/src/lang/module/index.test.fnk.snap
+++ b/src/lang/module/index.test.fnk.snap
@@ -3,20 +3,7 @@
 exports[`module handles comments 1`] = `
 "#!/usr/bin/env node
 // leading comment
-// static imports
-import \\"shrub\\";
-import \\"@fink/foo/bar.js\\";
-// default import
-import foo from \\"./foo.js\\";
-// import exported values
-import { bar } from \\"./spam.js\\";
-import { foo as spam } from \\"./shrub.js\\";
-// dynamic imports with static URL
-export const ni = await import(\`./shrub.js\`);
-// dynamic imports with dynamic URLs
-export const shrub = foo + bar;
-export const ni2 = await import(shrub);
-export const ni3 = await import(\`\${shrub}\`);
-export const ni4 = await import(\`./\${shrub}.js\`);
+// expr comment
+export const foo = 1234;
 // trailing comment"
 `;


### PR DESCRIPTION
Add options to set different file ext for relative and aboslute imports when explicit .fnk ext.

BREAKING CHANGE: babel config has now moved to its own key `{babel: {...}}` in the options, use_babel_config has been removed