### PR TITLE
feat(iterables): improve consistency and accu handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -528,13 +528,13 @@
       }
     },
     "node_modules/@fink/cli": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@fink/cli/-/cli-8.0.0.tgz",
-      "integrity": "sha512-bBICg26ZmxA8N1ESDp30lT0QfwizNvLCuzFd0NVW9ikRGEcDH04omJPRqDfCU+P9LwEZM/kmwx3RRqQb0EeKWQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@fink/cli/-/cli-8.1.0.tgz",
+      "integrity": "sha512-p2Ah+/YFOHv0L1erHceVRwjJWWcRVOR6bynhlIRRXV5SRUoRedagaKIcTE8c4OrfZdpm+9WBquqkMvHamt06KA==",
       "dev": true,
       "dependencies": {
-        "@fink/js-interop": "^2.0.0",
-        "@fink/std-lib": "^5.0.0",
+        "@fink/js-interop": "^2.0.1",
+        "@fink/std-lib": "^6.0.0",
         "minimatch": "^3.0.4",
         "yargs": "^16.0.3"
       },
@@ -549,27 +549,15 @@
         "@fink/loxia": ">=14.0.2"
       }
     },
-    "node_modules/@fink/cli/node_modules/@fink/std-lib": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@fink/std-lib/-/std-lib-5.0.0.tgz",
-      "integrity": "sha512-bcxg8DcsAxalb2ekEH4q1W3Ud5DtZ0ud3L0OfD+TnAVtNWzUl8q03AaAbmfebjjrGHQfV1c1djW+6FJw8Tc1zA==",
-      "dev": true,
-      "dependencies": {
-        "@fink/js-interop": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@fink/jest": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@fink/jest/-/jest-7.0.0.tgz",
-      "integrity": "sha512-cgxOUBpUj6LMo1KtOQVKrmRRxemL+Q0iICxUiL7VMFYBhYJy360/H4optKiFof5s4mSbaNHpJhf6AOiJeK4BXQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@fink/jest/-/jest-7.1.0.tgz",
+      "integrity": "sha512-t1t3b5l6GB3Adra5GslzM5NxlTbVypuu3b8UsJG8k2EsGCO6b5npIredfc3HLESfJVxNW2xmgMvvo2uhPqvzjw==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
-        "@fink/js-interop": "^2.0.0",
-        "@fink/std-lib": "^5.0.0"
+        "@fink/js-interop": "^2.0.1",
+        "@fink/std-lib": "^6.0.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -577,18 +565,6 @@
       "peerDependencies": {
         "@fink/larix": ">=13.0.0",
         "@fink/loxia": ">=14.0.0"
-      }
-    },
-    "node_modules/@fink/jest/node_modules/@fink/std-lib": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@fink/std-lib/-/std-lib-5.0.0.tgz",
-      "integrity": "sha512-bcxg8DcsAxalb2ekEH4q1W3Ud5DtZ0ud3L0OfD+TnAVtNWzUl8q03AaAbmfebjjrGHQfV1c1djW+6FJw8Tc1zA==",
-      "dev": true,
-      "dependencies": {
-        "@fink/js-interop": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@fink/js-interop": {
@@ -600,34 +576,22 @@
       }
     },
     "node_modules/@fink/larix": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@fink/larix/-/larix-15.0.0.tgz",
-      "integrity": "sha512-ujzBqVRe6BrK5Ze2107IVrpYZ6LT/RUcHT+e2JZFbWXyX6V77oRiKXFf79XTsURwmLT9+hjnDxQARwyPvtxajQ==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@fink/larix/-/larix-15.1.0.tgz",
+      "integrity": "sha512-VNuOq2Mk34UFlM4fKpVhTfwUwfThdS760kE/P9k91ZsNdX5yU16OMIRSm07o/1dueCuIr8lT07sLvh9oWXCFEQ==",
       "dev": true,
       "dependencies": {
-        "@fink/prattler": "^6.1.0",
-        "@fink/std-lib": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@fink/larix/node_modules/@fink/std-lib": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@fink/std-lib/-/std-lib-5.0.0.tgz",
-      "integrity": "sha512-bcxg8DcsAxalb2ekEH4q1W3Ud5DtZ0ud3L0OfD+TnAVtNWzUl8q03AaAbmfebjjrGHQfV1c1djW+6FJw8Tc1zA==",
-      "dev": true,
-      "dependencies": {
-        "@fink/js-interop": "^2.0.0"
+        "@fink/prattler": "^6.2.0",
+        "@fink/std-lib": "^6.0.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@fink/loxia": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@fink/loxia/-/loxia-17.0.0.tgz",
-      "integrity": "sha512-aGm7c5uJLDHMVSYFwhI+lY7ADizLtALqayz9kTLKuwfiTXgNKYeZ8xJUqnEbBexKOFd2UgkLHpIJRWAtOetCNw==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/@fink/loxia/-/loxia-17.1.0.tgz",
+      "integrity": "sha512-ObmLuJzw7hbmtXw85ZnKgAdgyVN0v2+WRrgqz/X7FR280jBoQtDGiUYxPFpx/kYGB+4dygIg3rwtbVtq5cwsBQ==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.10.5",
@@ -635,19 +599,7 @@
         "@babel/types": "^7.10.5",
         "@fink/js-interop": "^2.0.1",
         "@fink/snippet": "^2.0.1",
-        "@fink/std-lib": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@fink/loxia/node_modules/@fink/std-lib": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@fink/std-lib/-/std-lib-5.0.0.tgz",
-      "integrity": "sha512-bcxg8DcsAxalb2ekEH4q1W3Ud5DtZ0ud3L0OfD+TnAVtNWzUl8q03AaAbmfebjjrGHQfV1c1djW+6FJw8Tc1zA==",
-      "dev": true,
-      "dependencies": {
-        "@fink/js-interop": "^2.0.0"
+        "@fink/std-lib": "^6.0.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -2037,9 +1989,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.14.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.3.tgz",
-      "integrity": "sha512-33/L34xS7HVUx23e0wOT2V1qPF1IrHgQccdJVm9uXGTB9vFBrrzBtkQymT8VskeKOxjz55MSqMv0xuLq+u98WQ==",
+      "version": "14.14.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.6.tgz",
+      "integrity": "sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -3836,9 +3788,9 @@
       "dev": true
     },
     "node_modules/execa": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
-      "integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
       "dev": true,
       "dependencies": {
         "cross-spawn": "^7.0.0",
@@ -4254,9 +4206,9 @@
       "dev": true
     },
     "node_modules/fastq": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
-      "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.9.0.tgz",
+      "integrity": "sha512-i7FVWL8HhVY+CTkwFxkN2mk3h+787ixS5S63eb78diVRc1MCssarHq3W5cj0av7YDSwmaV928RNag+U1etRQ7w==",
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
@@ -4469,9 +4421,9 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "node_modules/gensync": {
-      "version": "1.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
-      "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -7324,9 +7276,9 @@
       }
     },
     "node_modules/jest-validate/node_modules/camelcase": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.1.0.tgz",
-      "integrity": "sha512-WCMml9ivU60+8rEJgELlFp1gxFcEGxwYleE3bziHEDeqsqAWGHdimB7beBFGjLzVNgPGyDsfgXLQEYMpmIFnVQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+      "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -14786,13 +14738,13 @@
       "dev": true
     },
     "node_modules/prompts": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
-      "integrity": "sha512-Q06uKs2CkNYVID0VqwfAl9mipo99zkBv/n2JtWY89Yxa3ZabWSrs0e2KTudKVa3peLUvYXMefDqIleLPVUBZMA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.0.tgz",
+      "integrity": "sha512-awZAKrk3vN6CroQukBL+R9051a4R3zCZBlJm/HBfrSZ8iTpYix3VX1vU4mveiLpiwmOJT4wokTF9m6HUk4KqWQ==",
       "dev": true,
       "dependencies": {
         "kleur": "^3.0.3",
-        "sisteransi": "^1.0.4"
+        "sisteransi": "^1.0.5"
       },
       "engines": {
         "node": ">= 6"
@@ -15303,10 +15255,24 @@
       }
     },
     "node_modules/run-parallel": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
-      "dev": true
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
+      "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/rxjs": {
       "version": "6.6.3",
@@ -15507,9 +15473,9 @@
       }
     },
     "node_modules/semantic-release": {
-      "version": "17.2.1",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-17.2.1.tgz",
-      "integrity": "sha512-+xbLWsT9NoibeMMJw4te0pbY4q/Z1gt/vzhB0z9RRNGVyqCgQiK5NUJ11eW6etSyPZ9QFeAMnqO2dzscWUTy2w==",
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-17.2.2.tgz",
+      "integrity": "sha512-LNU68ud3a3oU46H11OThXaKAK430jGGGTIF4VsiP843kRmS6s8kVCceLRdi7yWWz/sCCMD0zygPTQV2Jw79J5g==",
       "dev": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^8.0.0",
@@ -18258,48 +18224,26 @@
       "optional": true
     },
     "@fink/cli": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@fink/cli/-/cli-8.0.0.tgz",
-      "integrity": "sha512-bBICg26ZmxA8N1ESDp30lT0QfwizNvLCuzFd0NVW9ikRGEcDH04omJPRqDfCU+P9LwEZM/kmwx3RRqQb0EeKWQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@fink/cli/-/cli-8.1.0.tgz",
+      "integrity": "sha512-p2Ah+/YFOHv0L1erHceVRwjJWWcRVOR6bynhlIRRXV5SRUoRedagaKIcTE8c4OrfZdpm+9WBquqkMvHamt06KA==",
       "dev": true,
       "requires": {
-        "@fink/js-interop": "^2.0.0",
-        "@fink/std-lib": "^5.0.0",
+        "@fink/js-interop": "^2.0.1",
+        "@fink/std-lib": "^6.0.0",
         "minimatch": "^3.0.4",
         "yargs": "^16.0.3"
-      },
-      "dependencies": {
-        "@fink/std-lib": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@fink/std-lib/-/std-lib-5.0.0.tgz",
-          "integrity": "sha512-bcxg8DcsAxalb2ekEH4q1W3Ud5DtZ0ud3L0OfD+TnAVtNWzUl8q03AaAbmfebjjrGHQfV1c1djW+6FJw8Tc1zA==",
-          "dev": true,
-          "requires": {
-            "@fink/js-interop": "^2.0.0"
-          }
-        }
       }
     },
     "@fink/jest": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@fink/jest/-/jest-7.0.0.tgz",
-      "integrity": "sha512-cgxOUBpUj6LMo1KtOQVKrmRRxemL+Q0iICxUiL7VMFYBhYJy360/H4optKiFof5s4mSbaNHpJhf6AOiJeK4BXQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@fink/jest/-/jest-7.1.0.tgz",
+      "integrity": "sha512-t1t3b5l6GB3Adra5GslzM5NxlTbVypuu3b8UsJG8k2EsGCO6b5npIredfc3HLESfJVxNW2xmgMvvo2uhPqvzjw==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.11.6",
-        "@fink/js-interop": "^2.0.0",
-        "@fink/std-lib": "^5.0.0"
-      },
-      "dependencies": {
-        "@fink/std-lib": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@fink/std-lib/-/std-lib-5.0.0.tgz",
-          "integrity": "sha512-bcxg8DcsAxalb2ekEH4q1W3Ud5DtZ0ud3L0OfD+TnAVtNWzUl8q03AaAbmfebjjrGHQfV1c1djW+6FJw8Tc1zA==",
-          "dev": true,
-          "requires": {
-            "@fink/js-interop": "^2.0.0"
-          }
-        }
+        "@fink/js-interop": "^2.0.1",
+        "@fink/std-lib": "^6.0.0"
       }
     },
     "@fink/js-interop": {
@@ -18308,30 +18252,19 @@
       "integrity": "sha512-WDjgBWf6hSS3aAP9lMM+OYJOQTOaWoPvWDgN+7IakSacplsX2omk6bdpE1sYBwSLEqfAQ0ZuyybfdGv83WM/WA=="
     },
     "@fink/larix": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@fink/larix/-/larix-15.0.0.tgz",
-      "integrity": "sha512-ujzBqVRe6BrK5Ze2107IVrpYZ6LT/RUcHT+e2JZFbWXyX6V77oRiKXFf79XTsURwmLT9+hjnDxQARwyPvtxajQ==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@fink/larix/-/larix-15.1.0.tgz",
+      "integrity": "sha512-VNuOq2Mk34UFlM4fKpVhTfwUwfThdS760kE/P9k91ZsNdX5yU16OMIRSm07o/1dueCuIr8lT07sLvh9oWXCFEQ==",
       "dev": true,
       "requires": {
-        "@fink/prattler": "^6.1.0",
-        "@fink/std-lib": "^5.0.0"
-      },
-      "dependencies": {
-        "@fink/std-lib": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@fink/std-lib/-/std-lib-5.0.0.tgz",
-          "integrity": "sha512-bcxg8DcsAxalb2ekEH4q1W3Ud5DtZ0ud3L0OfD+TnAVtNWzUl8q03AaAbmfebjjrGHQfV1c1djW+6FJw8Tc1zA==",
-          "dev": true,
-          "requires": {
-            "@fink/js-interop": "^2.0.0"
-          }
-        }
+        "@fink/prattler": "^6.2.0",
+        "@fink/std-lib": "^6.0.0"
       }
     },
     "@fink/loxia": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@fink/loxia/-/loxia-17.0.0.tgz",
-      "integrity": "sha512-aGm7c5uJLDHMVSYFwhI+lY7ADizLtALqayz9kTLKuwfiTXgNKYeZ8xJUqnEbBexKOFd2UgkLHpIJRWAtOetCNw==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/@fink/loxia/-/loxia-17.1.0.tgz",
+      "integrity": "sha512-ObmLuJzw7hbmtXw85ZnKgAdgyVN0v2+WRrgqz/X7FR280jBoQtDGiUYxPFpx/kYGB+4dygIg3rwtbVtq5cwsBQ==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.10.5",
@@ -18339,18 +18272,7 @@
         "@babel/types": "^7.10.5",
         "@fink/js-interop": "^2.0.1",
         "@fink/snippet": "^2.0.1",
-        "@fink/std-lib": "^5.0.0"
-      },
-      "dependencies": {
-        "@fink/std-lib": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@fink/std-lib/-/std-lib-5.0.0.tgz",
-          "integrity": "sha512-bcxg8DcsAxalb2ekEH4q1W3Ud5DtZ0ud3L0OfD+TnAVtNWzUl8q03AaAbmfebjjrGHQfV1c1djW+6FJw8Tc1zA==",
-          "dev": true,
-          "requires": {
-            "@fink/js-interop": "^2.0.0"
-          }
-        }
+        "@fink/std-lib": "^6.0.0"
       }
     },
     "@fink/prattler": {
@@ -19467,9 +19389,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.3.tgz",
-      "integrity": "sha512-33/L34xS7HVUx23e0wOT2V1qPF1IrHgQccdJVm9uXGTB9vFBrrzBtkQymT8VskeKOxjz55MSqMv0xuLq+u98WQ==",
+      "version": "14.14.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.6.tgz",
+      "integrity": "sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -20893,9 +20815,9 @@
       "dev": true
     },
     "execa": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
-      "integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
       "dev": true,
       "requires": {
         "cross-spawn": "^7.0.0",
@@ -21230,9 +21152,9 @@
       "dev": true
     },
     "fastq": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
-      "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.9.0.tgz",
+      "integrity": "sha512-i7FVWL8HhVY+CTkwFxkN2mk3h+787ixS5S63eb78diVRc1MCssarHq3W5cj0av7YDSwmaV928RNag+U1etRQ7w==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -21404,9 +21326,9 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "gensync": {
-      "version": "1.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
-      "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg=="
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -23580,9 +23502,9 @@
           }
         },
         "camelcase": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.1.0.tgz",
-          "integrity": "sha512-WCMml9ivU60+8rEJgELlFp1gxFcEGxwYleE3bziHEDeqsqAWGHdimB7beBFGjLzVNgPGyDsfgXLQEYMpmIFnVQ==",
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+          "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
           "dev": true
         },
         "chalk": {
@@ -29487,13 +29409,13 @@
       "dev": true
     },
     "prompts": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
-      "integrity": "sha512-Q06uKs2CkNYVID0VqwfAl9mipo99zkBv/n2JtWY89Yxa3ZabWSrs0e2KTudKVa3peLUvYXMefDqIleLPVUBZMA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.0.tgz",
+      "integrity": "sha512-awZAKrk3vN6CroQukBL+R9051a4R3zCZBlJm/HBfrSZ8iTpYix3VX1vU4mveiLpiwmOJT4wokTF9m6HUk4KqWQ==",
       "dev": true,
       "requires": {
         "kleur": "^3.0.3",
-        "sisteransi": "^1.0.4"
+        "sisteransi": "^1.0.5"
       }
     },
     "pseudomap": {
@@ -29886,9 +29808,9 @@
       "dev": true
     },
     "run-parallel": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
+      "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==",
       "dev": true
     },
     "rxjs": {
@@ -30050,9 +29972,9 @@
       }
     },
     "semantic-release": {
-      "version": "17.2.1",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-17.2.1.tgz",
-      "integrity": "sha512-+xbLWsT9NoibeMMJw4te0pbY4q/Z1gt/vzhB0z9RRNGVyqCgQiK5NUJ11eW6etSyPZ9QFeAMnqO2dzscWUTy2w==",
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-17.2.2.tgz",
+      "integrity": "sha512-LNU68ud3a3oU46H11OThXaKAK430jGGGTIF4VsiP843kRmS6s8kVCceLRdi7yWWz/sCCMD0zygPTQV2Jw79J5g==",
       "dev": true,
       "requires": {
         "@semantic-release/commit-analyzer": "^8.0.0",

--- a/src/lang/async/init.test.fnk.snap
+++ b/src/lang/async/init.test.fnk.snap
@@ -8,34 +8,34 @@ export const task3 = async (foo) => {
   const spam = await foo();
   return bar + 123;
 };
-export const a_gen = function unfold(ˆinitial_2) {
+export const a_gen = function unfold(ˆinitial_5) {
   return {
     async *[Symbol.asyncIterator]() {
-      let ˆaccu_3 = 0;
+      let ˆitem_1 = ˆinitial_5;
 
       while (true) {
-        const curr = ˆaccu_3;
+        const curr = ˆitem_1 === undefined ? 0 : ˆitem_1;
 
         let _do_result;
 
-        ˆmatch_5: {
-          const ˆvalue_4 = shrub;
+        ˆmatch_4: {
+          const ˆvalue_3 = shrub;
 
-          if (ˆvalue_4 === spam) {
+          if (ˆvalue_3 === spam) {
             _do_result = await ni(curr);
-            break ˆmatch_5;
+            break ˆmatch_4;
           }
 
           {
             _do_result = curr + 1;
-            break ˆmatch_5;
+            break ˆmatch_4;
           }
         }
 
-        const ˆresult_1 = _do_result;
+        const ˆresult_2 = _do_result;
         _do_result = undefined;
-        yield ˆresult_1;
-        ˆaccu_3 = ˆresult_1;
+        yield ˆresult_2;
+        ˆitem_1 = ˆresult_2;
       }
     }
 
@@ -53,16 +53,16 @@ exports[`await handles awaiting async iterables 1`] = `
   {
     let ˆpipe_result_3 = undefined;
 
-    _do_result2 = ˆpipe_result_3 = function unfold(ˆinitial_5) {
+    _do_result2 = ˆpipe_result_3 = function unfold(ˆinitial_6) {
       return {
         async *[Symbol.asyncIterator]() {
-          let ˆaccu_6 = 0;
+          let ˆitem_4 = ˆinitial_6;
 
           while (true) {
-            const cntr = ˆaccu_6;
-            const ˆresult_4 = (await cntr) + 1;
-            yield ˆresult_4;
-            ˆaccu_6 = ˆresult_4;
+            const cntr = ˆitem_4 === undefined ? 0 : ˆitem_4;
+            const ˆresult_5 = (await cntr) + 1;
+            yield ˆresult_5;
+            ˆitem_4 = ˆresult_5;
           }
         }
 

--- a/src/lang/call/pipe.test.fnk.snap
+++ b/src/lang/call/pipe.test.fnk.snap
@@ -17,13 +17,13 @@ exports[`pipe compiles 1`] = `
 {
   let ˆpipe_result_2 = [1, 2, 3];
 
-  ˆpipe_result_2 = function map(ˆitems_4) {
+  ˆpipe_result_2 = function map(ˆitems_5) {
     return {
       *[Symbol.iterator]() {
-        for (const ˆitem_3 of ˆitems_4) {
+        for (const ˆitem_3 of ˆitems_5) {
           const item = ˆitem_3;
-          const ˆresult_5 = item * 2;
-          yield ˆresult_5;
+          const ˆresult_4 = item * 2;
+          yield ˆresult_4;
         }
       }
 

--- a/src/lang/errors.fnk
+++ b/src/lang/errors.fnk
@@ -16,6 +16,6 @@ transform_error = fn message, expr, ctx:
 
     ${message}
     '
-    {transform_error: true}
+    {transform_error: true, expr}
 
 

--- a/src/lang/iterable/common.fnk
+++ b/src/lang/iterable/common.fnk
@@ -1,60 +1,92 @@
+babe_types = import '@babel/types'
+{
+  conditionalExpression
+} = babe_types
+
+
 {length} = import '@fink/std-lib/iter.fnk'
 
-{consts, yields, lets, assign, unique_ident} = import '../../js/types.fnk'
+{consts, lets, assign, unique_ident, undef, eq} = import '../../js/types.fnk'
 {exprs_block} = import '../block/init.fnk'
 {transform} = import '../transform.fnk'
 
 
 
 transform_init = fn left, right, ctx:
-  [item_init, next_ctx] = transform
+  true_left = match left:
+    {type: 'assign'}:
+      left.left
+    else:
+      left
+
+  [item_init, right_ctx] = transform
     dict:
       type: 'assign'
       op: '='
-      left
+      left: true_left
       right: {type: 'ident', value: right.name, loc: left.loc}
       loc: left.loc
     ctx
 
-  js = consts item_init.left, item_init.right
+  [right_js, next_ctx] = match left:
+    {type: 'assign'}:
+      [value, next_ctx] = transform left.right, right_ctx
+      cond = conditionalExpression
+        eq right, undef _
+        value
+        item_init.right
+      [cond, next_ctx]
+    else:
+      [item_init.right, right_ctx]
+
+  js = consts item_init.left, right_js
   [js, next_ctx]
 
 
 
-yield_expr = fn result, expr, ctx:
-  [yield_value, is_spread] = match expr:
-    {type: 'spread'}: [expr.right, true]
-    else: [expr, false]
-
-  [result_value, next_ctx] = transform yield_value, ctx
-
-  exprs = list:
-    consts result, result_value
-    yields result, is_spread
-
-  [exprs, next_ctx]
+unique_idents = fn names, ctx:
+  names | fold name, [ids, curr_ctx]=[[], ctx]:
+    [id, next_ctx] = unique_ident name, curr_ctx
+    next_ids = [...ids,  id]
+    [next_ids, next_ctx]
 
 
 
-get_accs = fn node, last_expr, ctx:
+get_accs = fn node, ctx:
   [, acc_arg] = node.args
+  [...exprs, last_expr] = node.exprs
+
+  [result_expr, result_is_spread] = match last_expr:
+    {type: 'spread'}:
+      [last_expr.right, true]
+    else:
+      [last_expr, false]
 
   match node.args:
     2 == length ?:
-      [acc, acc_init_ctx] = unique_ident 'accu', ctx
+      [[acc, result, next_accu], acc_init_ctx] = unique_idents
+        ['accu', 'result', 'next_accu'], ctx
+
       [acc_init_value, init_ctx] = transform acc_arg.right, acc_init_ctx
       acc_init = lets acc, acc_init_value
 
       [acc_assign, acc_ctx] = transform_init acc_arg.left, acc, init_ctx
 
-      [result_expr, acc_expr] = last_expr.exprs
-      [acc_val, next_ctx] = transform acc_expr, acc_ctx
-      next_acc_assign = assign acc, acc_val
+      [result_expr_val, next_ctx] = transform result_expr, acc_ctx
 
-      [[acc_init], [acc_assign], result_expr, [next_acc_assign], acc, next_ctx]
+      result_acc_assign = consts
+        {type: 'ArrayPattern', elements: [result, next_accu]}
+        result_expr_val
+
+      next_acc_assign = assign acc, next_accu
+
+      [[acc_init], [acc_assign], exprs, result_is_spread, [result_acc_assign, next_acc_assign], result, next_ctx]
 
     else:
-      [[], [], last_expr, [], false, ctx]
+      [result, acc_ctx] = unique_ident 'result', ctx
+      [result_expr_val, next_ctx] = transform result_expr, acc_ctx
+      result_assign = consts result, result_expr_val
+      [[], [], exprs, result_is_spread, [result_assign], result, next_ctx]
 
 
 
@@ -65,46 +97,38 @@ get_item = fn node, ctx:
   match item_arg:
     {type: 'empty'}:
       [item, [], init_ctx]
-    else:
+    {}:
       [item_init, next_ctx] = transform_init item_arg, item, init_ctx
       [item, [item_init], next_ctx]
+    else:
+      [item, [], init_ctx]
 
 
 
-get_iter_helpers = fn node, ctx:
+get_iter_helpers = fn node, ctx, input_name='items':
   [item, item_init, acc_ctx] = get_item node, ctx
 
   # TODO move next line into get_accs?
-  [...exprs, last_expr] = node.exprs
-  [acc_init, acc_assign, result_expr1, next_accu, accu, items_ctx] = get_accs
-    node, last_expr, acc_ctx
+  [acc_init, acc_assign, exprs, result_is_spread, foo, result, items_ctx] = get_accs
+    node, acc_ctx
 
-  [items, result_ctx] = unique_ident 'items', items_ctx
-  [result, exprs_ctx] = unique_ident 'result', result_ctx
+  [items, exprs_ctx] = unique_ident input_name, items_ctx
 
-  item_acc_assign = [...item_init, ...acc_assign]
-
-  [result_expr, result_is_spread] = match result_expr1:
-    {type: 'spread'}:
-      [result_expr1.right, true]
-    else:
-      [result_expr1, false]
 
   [expressions, next_ctx] = pipe exprs:
     exprs_block ?, exprs_ctx
 
     fn [exprs, result_ctx]:
-      [result_value, next_ctx] = transform result_expr, result_ctx
-      result_const = consts result, result_value
-      [[...exprs, result_const], next_ctx]
+      [[...exprs, ...foo], result_ctx]
 
   dict:
-    accu, acc_init
+    acc_init
     item, items
-    item_acc_assign
+    item_init
+    item_acc_assign: [...item_init, ...acc_assign]
     expressions
-    result, result_is_spread
-    next_accu
+    result
+    result_is_spread
     next_ctx
 
 

--- a/src/lang/iterable/filter.fnk
+++ b/src/lang/iterable/filter.fnk
@@ -14,7 +14,6 @@ transform_filter = fn node, ctx:
     item_acc_assign
     expressions
     result
-    next_accu
     next_ctx
   } = get_iter_helpers node, ctx
 
@@ -25,13 +24,11 @@ transform_filter = fn node, ctx:
 
     for_of [item, items],
       ...item_acc_assign
-
       ...expressions
 
       ifStatement
         result
         yields item
 
-      ...next_accu
-
   [js, next_ctx]
+

--- a/src/lang/iterable/filter.test.fnk
+++ b/src/lang/iterable/filter.test.fnk
@@ -23,21 +23,21 @@ describe 'filter', fn:
     expect
       fink2js '
         filter item, cntr=0:
-          (item < 1 and cntr % 2 == 0, cntr + 1)
+          [item < 1 and cntr % 2 == 0, cntr + 1]
       '
       to_match_snapshot
 
     expect
       fink2js '
         filter _, is_even=false:
-          (is_even, not is_even)
+          [is_even, not is_even]
       '
       to_match_snapshot
 
     expect
       fink2js '
         filter , is_even=false:
-          (is_even, not is_even)
+          [is_even, not is_even]
       '
       to_match_snapshot
 

--- a/src/lang/iterable/filter.test.fnk.snap
+++ b/src/lang/iterable/filter.test.fnk.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`filter async compiles 1`] = `
-"(function filter(ˆitems_2) {
+"(function filter(ˆitems_3) {
   return {
     async *[Symbol.asyncIterator]() {
-      for await (const ˆitem_1 of ˆitems_2) {
+      for await (const ˆitem_1 of ˆitems_3) {
         const item = ˆitem_1;
-        const ˆresult_3 = (await item) % 2 === 0;
-        if (ˆresult_3) yield ˆitem_1;
+        const ˆresult_2 = (await item) % 2 === 0;
+        if (ˆresult_2) yield ˆitem_1;
       }
     }
 
@@ -16,37 +16,37 @@ exports[`filter async compiles 1`] = `
 `;
 
 exports[`filter compiles 1`] = `
-"(function filter(ˆitems_2) {
+"(function filter(ˆitems_3) {
   return {
     *[Symbol.iterator]() {
-      for (const ˆitem_1 of ˆitems_2) {
+      for (const ˆitem_1 of ˆitems_3) {
         const item = ˆitem_1;
-        const ˆresult_3 = item % 2 === 0;
-        if (ˆresult_3) yield ˆitem_1;
+        const ˆresult_2 = item % 2 === 0;
+        if (ˆresult_2) yield ˆitem_1;
       }
     }
 
   };
 });
 
-(function filter(ˆitems_5) {
+(function filter(ˆitems_6) {
   return {
     *[Symbol.iterator]() {
-      for (const ˆitem_4 of ˆitems_5) {
+      for (const ˆitem_4 of ˆitems_6) {
         const [a, ...b] = ˆitem_4;
         const a_alone = a(andis_empty(b));
-        const ˆresult_6 = a_alone;
-        if (ˆresult_6) yield ˆitem_4;
+        const ˆresult_5 = a_alone;
+        if (ˆresult_5) yield ˆitem_4;
       }
     }
 
   };
 });
 
-(function filter(ˆitems_9) {
+(function filter(ˆitems_10) {
   return {
     *[Symbol.iterator]() {
-      for (const ˆitem_7 of ˆitems_9) {
+      for (const ˆitem_7 of ˆitems_10) {
         let _do_result;
 
         {
@@ -55,8 +55,8 @@ exports[`filter compiles 1`] = `
         }
         const [a, [b]] = _do_result;
         _do_result = undefined;
-        const ˆresult_10 = b && is_empty(a);
-        if (ˆresult_10) yield ˆitem_7;
+        const ˆresult_9 = b && is_empty(a);
+        if (ˆresult_9) yield ˆitem_7;
       }
     }
 
@@ -65,17 +65,17 @@ exports[`filter compiles 1`] = `
 `;
 
 exports[`filter compiles with accu 1`] = `
-"(function filter(ˆitems_3) {
+"(function filter(ˆitems_5) {
   return {
     *[Symbol.iterator]() {
       let ˆaccu_2 = 0;
 
-      for (const ˆitem_1 of ˆitems_3) {
+      for (const ˆitem_1 of ˆitems_5) {
         const item = ˆitem_1;
         const cntr = ˆaccu_2;
-        const ˆresult_4 = item < 1 && cntr % 2 === 0;
-        if (ˆresult_4) yield ˆitem_1;
-        ˆaccu_2 = cntr + 1;
+        const [ˆresult_3, ˆnext_accu_4] = [item < 1 && cntr % 2 === 0, cntr + 1];
+        ˆaccu_2 = ˆnext_accu_4;
+        if (ˆresult_3) yield ˆitem_1;
       }
     }
 
@@ -84,16 +84,16 @@ exports[`filter compiles with accu 1`] = `
 `;
 
 exports[`filter compiles with accu 2`] = `
-"(function filter(ˆitems_3) {
+"(function filter(ˆitems_5) {
   return {
     *[Symbol.iterator]() {
       let ˆaccu_2 = false;
 
-      for (const ˆitem_1 of ˆitems_3) {
+      for (const ˆitem_1 of ˆitems_5) {
         const is_even = ˆaccu_2;
-        const ˆresult_4 = is_even;
-        if (ˆresult_4) yield ˆitem_1;
-        ˆaccu_2 = !is_even;
+        const [ˆresult_3, ˆnext_accu_4] = [is_even, !is_even];
+        ˆaccu_2 = ˆnext_accu_4;
+        if (ˆresult_3) yield ˆitem_1;
       }
     }
 
@@ -102,16 +102,16 @@ exports[`filter compiles with accu 2`] = `
 `;
 
 exports[`filter compiles with accu 3`] = `
-"(function filter(ˆitems_3) {
+"(function filter(ˆitems_5) {
   return {
     *[Symbol.iterator]() {
       let ˆaccu_2 = false;
 
-      for (const ˆitem_1 of ˆitems_3) {
+      for (const ˆitem_1 of ˆitems_5) {
         const is_even = ˆaccu_2;
-        const ˆresult_4 = is_even;
-        if (ˆresult_4) yield ˆitem_1;
-        ˆaccu_2 = !is_even;
+        const [ˆresult_3, ˆnext_accu_4] = [is_even, !is_even];
+        ˆaccu_2 = ˆnext_accu_4;
+        if (ˆresult_3) yield ˆitem_1;
       }
     }
 

--- a/src/lang/iterable/fold.fnk
+++ b/src/lang/iterable/fold.fnk
@@ -1,50 +1,62 @@
-{assign, for_of, func, lets, undef, unique_ident} = import '../../js/types.fnk'
-{exprs_block} = import '../block/init.fnk'
+{assign, for_of, func, lets, unique_ident} = import '../../js/types.fnk'
 {transform} = import '../transform.fnk'
-{transform_init} = import './common.fnk'
+{get_iter_helpers, transform_init} = import './common.fnk'
 
 
 
-get_acc = fn acc_arg, ctx:
-  [acc, init_ctx] = unique_ident 'accu', ctx
+get_fold_result = fn node, ctx:
+  [, result_arg] = node.args
 
-  [acc_init, acc_ctx] = match acc_arg:
-    {}:
-      transform acc_arg.right, init_ctx
+  [fold_result, fold_init_ctx] = unique_ident 'fold_result', ctx
+
+  [fold_init, result_ctx] = match result_arg:
+    {type: 'assign'}:
+      [value, ccc] = transform result_arg.right, fold_init_ctx
+      seq:
+        lets fold_result, value
+        ccc
     else:
-      [(undef _), init_ctx]
+      seq:
+        lets fold_result
+        fold_init_ctx
 
-  [acc_assign, next_ctx] = match acc_arg:
+  [prev_result_assign, end_ctx] = match result_arg:
     {}:
-      [init, next_ctx] = transform_init acc_arg.left, acc, acc_ctx
-      [[init], next_ctx]
+      [prev_assign, next_ctx] = transform_init
+        result_arg.left, fold_result, result_ctx
+      [[prev_assign], next_ctx]
     else:
-      [[], acc_ctx]
+      [[], result_ctx]
 
-  [acc, acc_init, acc_assign, next_ctx]
+  [fold_result, fold_init, prev_result_assign, end_ctx]
 
 
 
 transform_fold = fn node, ctx:
-  [item_arg, acc_arg] = node.args
-  [...expressions, last_expr] = node.exprs
+  [item_arg, _, ...acc_args] = node.args
 
-  [item, init_ctx] = unique_ident 'item', ctx
-  [item_init, acc_ctx] = transform_init item_arg, item, init_ctx
-  [acc, acc_init, acc_assign, items_ctx] = get_acc acc_arg, acc_ctx
+  {
+    acc_init
+    item, items
+    item_acc_assign
+    expressions
+    next_ctx
+    result
+  } = get_iter_helpers {...node, args: [item_arg, ...acc_args]}, ctx
 
-  [items, block_ctx] = unique_ident 'items', items_ctx
-  [body, result_ctx] = exprs_block expressions, block_ctx
-  [result, end_ctx] = transform last_expr, result_ctx
+  [fold_result, fold_init, prev_result_assign, end_ctx] = get_fold_result node, next_ctx
+
 
   js = func [items],
-    lets acc, acc_init
+    ...acc_init
+    fold_init
 
     for_of [item, items],
-      ...acc_assign
-      item_init
-      ...body
-      assign acc, result
-    acc
+      ...item_acc_assign
+      ...prev_result_assign
+      ...expressions
+      assign fold_result, result
+
+    fold_result
 
   [js, end_ctx]

--- a/src/lang/iterable/fold.test.fnk
+++ b/src/lang/iterable/fold.test.fnk
@@ -6,14 +6,23 @@ describe 'fold', fn:
   it 'compiles', fn:
     expect
       fink2js '
-        fold item, acc=0:
-          ni = item + acc
-          item * acc
+        fold item, prev=0:
+          ni = item + prev
+          item * ni
       '
       to_match_snapshot
 
 
-  it 'compiles without accu', fn:
+   it 'compiles with accu', fn:
+    expect
+      fink2js '
+        fold item, prev=0, acc=1:
+          [item * acc + prev, acc + 1]
+      '
+      to_match_snapshot
+
+
+  it 'compiles without using prev result', fn:
     expect
       fink2js '
         fold item:
@@ -25,16 +34,16 @@ describe 'fold', fn:
   it 'destructuring item', fn:
     expect
       fink2js '
-        fold [foo, ...bar], acc=[]:
-          [[foo, bar], ...acc]
+        fold [foo, ...bar], prev=[]:
+          [[foo, bar], ...prev]
 
-        fold [...foo, bar], acc=[]:
-          [[foo, bar], ...acc]
+        fold [...foo, bar], prev=[]:
+          [[foo, bar], ...prev]
       '
       to_match_snapshot
 
 
-  it 'destructuring accu', fn:
+  it 'destructuring prev result', fn:
     expect
       fink2js '
         fold item, [foo, ...bar]=[]:

--- a/src/lang/iterable/fold.test.fnk.snap
+++ b/src/lang/iterable/fold.test.fnk.snap
@@ -2,110 +2,135 @@
 
 exports[`fold async compiles 1`] = `
 "async ˆitems_3 => {
-  let ˆaccu_2 = 0;
+  let ˆfold_result_4 = 0;
 
   for await (const ˆitem_1 of ˆitems_3) {
-    const acc = ˆaccu_2;
     const item = ˆitem_1;
+    const acc = ˆfold_result_4;
     const ni = (await item) + acc;
-    ˆaccu_2 = item * acc;
+    const ˆresult_2 = item * acc;
+    ˆfold_result_4 = ˆresult_2;
   }
 
-  return ˆaccu_2;
+  return ˆfold_result_4;
 };"
 `;
 
 exports[`fold compiles 1`] = `
 "ˆitems_3 => {
-  let ˆaccu_2 = 0;
+  let ˆfold_result_4 = 0;
 
   for (const ˆitem_1 of ˆitems_3) {
+    const item = ˆitem_1;
+    const prev = ˆfold_result_4;
+    const ni = item + prev;
+    const ˆresult_2 = item * ni;
+    ˆfold_result_4 = ˆresult_2;
+  }
+
+  return ˆfold_result_4;
+};"
+`;
+
+exports[`fold compiles with accu 1`] = `
+"ˆitems_5 => {
+  let ˆaccu_2 = 1;
+  let ˆfold_result_6 = 0;
+
+  for (const ˆitem_1 of ˆitems_5) {
+    const item = ˆitem_1;
     const acc = ˆaccu_2;
-    const item = ˆitem_1;
-    const ni = item + acc;
-    ˆaccu_2 = item * acc;
+    const prev = ˆfold_result_6;
+    const [ˆresult_3, ˆnext_accu_4] = [item * acc + prev, acc + 1];
+    ˆaccu_2 = ˆnext_accu_4;
+    ˆfold_result_6 = ˆresult_3;
   }
 
-  return ˆaccu_2;
+  return ˆfold_result_6;
 };"
 `;
 
-exports[`fold compiles without accu 1`] = `
+exports[`fold compiles without using prev result 1`] = `
 "ˆitems_3 => {
-  let ˆaccu_2 = undefined;
+  let ˆfold_result_4;
 
   for (const ˆitem_1 of ˆitems_3) {
     const item = ˆitem_1;
-    ˆaccu_2 = item;
+    const ˆresult_2 = item;
+    ˆfold_result_4 = ˆresult_2;
   }
 
-  return ˆaccu_2;
-};"
-`;
-
-exports[`fold destructuring accu 1`] = `
-"ˆitems_3 => {
-  let ˆaccu_2 = [];
-
-  for (const ˆitem_1 of ˆitems_3) {
-    const [foo, ...bar] = ˆaccu_2;
-    const item = ˆitem_1;
-    ˆaccu_2 = [item, bar, foo];
-  }
-
-  return ˆaccu_2;
-};
-
-ˆitems_7 => {
-  let ˆaccu_5 = [];
-
-  for (const ˆitem_4 of ˆitems_7) {
-    let _do_result;
-
-    {
-      const [...ˆitems_6] = ˆaccu_5;
-      _do_result = [ˆitems_6.slice(0, -1), ˆitems_6.slice(-1)];
-    }
-    const [foo, [bar]] = _do_result;
-    _do_result = undefined;
-    const item = ˆitem_4;
-    ˆaccu_5 = [item, bar, foo];
-  }
-
-  return ˆaccu_5;
+  return ˆfold_result_4;
 };"
 `;
 
 exports[`fold destructuring item 1`] = `
 "ˆitems_3 => {
-  let ˆaccu_2 = [];
+  let ˆfold_result_4 = [];
 
   for (const ˆitem_1 of ˆitems_3) {
-    const acc = ˆaccu_2;
     const [foo, ...bar] = ˆitem_1;
-    ˆaccu_2 = [[foo, bar], ...acc];
+    const prev = ˆfold_result_4;
+    const ˆresult_2 = [[foo, bar], ...prev];
+    ˆfold_result_4 = ˆresult_2;
   }
 
-  return ˆaccu_2;
+  return ˆfold_result_4;
+};
+
+ˆitems_8 => {
+  let ˆfold_result_9 = [];
+
+  for (const ˆitem_5 of ˆitems_8) {
+    let _do_result;
+
+    {
+      const [...ˆitems_6] = ˆitem_5;
+      _do_result = [ˆitems_6.slice(0, -1), ˆitems_6.slice(-1)];
+    }
+    const [foo, [bar]] = _do_result;
+    _do_result = undefined;
+    const prev = ˆfold_result_9;
+    const ˆresult_7 = [[foo, bar], ...prev];
+    ˆfold_result_9 = ˆresult_7;
+  }
+
+  return ˆfold_result_9;
+};"
+`;
+
+exports[`fold destructuring prev result 1`] = `
+"ˆitems_3 => {
+  let ˆfold_result_4 = [];
+
+  for (const ˆitem_1 of ˆitems_3) {
+    const item = ˆitem_1;
+    const [foo, ...bar] = ˆfold_result_4;
+    const ˆresult_2 = [item, bar, foo];
+    ˆfold_result_4 = ˆresult_2;
+  }
+
+  return ˆfold_result_4;
 };
 
 ˆitems_7 => {
-  let ˆaccu_6 = [];
+  let ˆfold_result_8 = [];
 
-  for (const ˆitem_4 of ˆitems_7) {
-    const acc = ˆaccu_6;
+  for (const ˆitem_5 of ˆitems_7) {
+    const item = ˆitem_5;
 
     let _do_result;
 
     {
-      const [...ˆitems_5] = ˆitem_4;
-      _do_result = [ˆitems_5.slice(0, -1), ˆitems_5.slice(-1)];
+      const [...ˆitems_9] = ˆfold_result_8;
+      _do_result = [ˆitems_9.slice(0, -1), ˆitems_9.slice(-1)];
     }
     const [foo, [bar]] = _do_result;
     _do_result = undefined;
-    ˆaccu_6 = [[foo, bar], ...acc];
+    const ˆresult_6 = [item, bar, foo];
+    ˆfold_result_8 = ˆresult_6;
   }
 
-  return ˆaccu_6;
+  return ˆfold_result_8;
 };"
 `;

--- a/src/lang/iterable/map.fnk
+++ b/src/lang/iterable/map.fnk
@@ -11,7 +11,6 @@ transform_map = fn node, ctx:
     item_acc_assign
     expressions
     result, result_is_spread
-    next_accu
     next_ctx
   } = get_iter_helpers node, ctx
 
@@ -24,6 +23,6 @@ transform_map = fn node, ctx:
       ...item_acc_assign
       ...expressions
       yields result, result_is_spread
-      ...next_accu
 
   [js, next_ctx]
+

--- a/src/lang/iterable/map.test.fnk
+++ b/src/lang/iterable/map.test.fnk
@@ -69,14 +69,14 @@ describe 'map', fn:
     expect
       fink2js '
         map {foo}, acc=0:
-          (foo + acc, acc+1)
+          [foo + acc, acc+1]
       '
       to_match_snapshot
 
     expect
       fink2js '
         map {foo}, acc=0:
-          (...[acc, foo], acc+1)
+          ...[[acc, foo], acc+1]
       '
       to_match_snapshot
 

--- a/src/lang/iterable/map.test.fnk.snap
+++ b/src/lang/iterable/map.test.fnk.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`map async compiles 1`] = `
-"(function map(ˆitems_2) {
+"(function map(ˆitems_3) {
   return {
     async *[Symbol.asyncIterator]() {
-      for await (const ˆitem_1 of ˆitems_2) {
+      for await (const ˆitem_1 of ˆitems_3) {
         const item = ˆitem_1;
-        const ˆresult_3 = (await item) * 2;
-        yield ˆresult_3;
+        const ˆresult_2 = (await item) * 2;
+        yield ˆresult_2;
       }
     }
 
@@ -16,13 +16,13 @@ exports[`map async compiles 1`] = `
 `;
 
 exports[`map compiles as flat map 1`] = `
-"(function map(ˆitems_2) {
+"(function map(ˆitems_3) {
   return {
     *[Symbol.iterator]() {
-      for (const ˆitem_1 of ˆitems_2) {
+      for (const ˆitem_1 of ˆitems_3) {
         const [x, y] = ˆitem_1;
-        const ˆresult_3 = [x, y];
-        yield* ˆresult_3;
+        const ˆresult_2 = [x, y];
+        yield* ˆresult_2;
       }
     }
 
@@ -31,23 +31,23 @@ exports[`map compiles as flat map 1`] = `
 `;
 
 exports[`map compiles destructuring 1`] = `
-"(function map(ˆitems_2) {
+"(function map(ˆitems_3) {
   return {
     *[Symbol.iterator]() {
-      for (const ˆitem_1 of ˆitems_2) {
+      for (const ˆitem_1 of ˆitems_3) {
         const [x, ...rest] = ˆitem_1;
-        const ˆresult_3 = rest;
-        yield ˆresult_3;
+        const ˆresult_2 = rest;
+        yield ˆresult_2;
       }
     }
 
   };
 });
 
-(function map(ˆitems_6) {
+(function map(ˆitems_7) {
   return {
     *[Symbol.iterator]() {
-      for (const ˆitem_4 of ˆitems_6) {
+      for (const ˆitem_4 of ˆitems_7) {
         let _do_result;
 
         {
@@ -56,8 +56,8 @@ exports[`map compiles destructuring 1`] = `
         }
         const [ignored, [last]] = _do_result;
         _do_result = undefined;
-        const ˆresult_7 = last;
-        yield ˆresult_7;
+        const ˆresult_6 = last;
+        yield ˆresult_6;
       }
     }
 
@@ -66,14 +66,14 @@ exports[`map compiles destructuring 1`] = `
 `;
 
 exports[`map compiles multi line 1`] = `
-"(function map(ˆitems_2) {
+"(function map(ˆitems_3) {
   return {
     *[Symbol.iterator]() {
-      for (const ˆitem_1 of ˆitems_2) {
+      for (const ˆitem_1 of ˆitems_3) {
         const item = ˆitem_1;
         const ni = foo(item);
-        const ˆresult_3 = ni + 2;
-        yield ˆresult_3;
+        const ˆresult_2 = ni + 2;
+        yield ˆresult_2;
       }
     }
 
@@ -82,13 +82,13 @@ exports[`map compiles multi line 1`] = `
 `;
 
 exports[`map compiles single line 1`] = `
-"(function map(ˆitems_2) {
+"(function map(ˆitems_3) {
   return {
     *[Symbol.iterator]() {
-      for (const ˆitem_1 of ˆitems_2) {
+      for (const ˆitem_1 of ˆitems_3) {
         const item = ˆitem_1;
-        const ˆresult_3 = item * 2;
-        yield ˆresult_3;
+        const ˆresult_2 = item * 2;
+        yield ˆresult_2;
       }
     }
 
@@ -97,13 +97,13 @@ exports[`map compiles single line 1`] = `
 `;
 
 exports[`map compiles single line with default value 1`] = `
-"(function map(ˆitems_2) {
+"(function map(ˆitems_3) {
   return {
     *[Symbol.iterator]() {
-      for (const ˆitem_1 of ˆitems_2) {
-        const item = 123 = ˆitem_1;
-        const ˆresult_3 = item * 2;
-        yield ˆresult_3;
+      for (const ˆitem_1 of ˆitems_3) {
+        const item = ˆitem_1 === undefined ? 123 : ˆitem_1;
+        const ˆresult_2 = item * 2;
+        yield ˆresult_2;
       }
     }
 
@@ -112,13 +112,13 @@ exports[`map compiles single line with default value 1`] = `
 `;
 
 exports[`map compiles single line with destructured list 1`] = `
-"(function map(ˆitems_2) {
+"(function map(ˆitems_3) {
   return {
     *[Symbol.iterator]() {
-      for (const ˆitem_1 of ˆitems_2) {
+      for (const ˆitem_1 of ˆitems_3) {
         const [x, y] = ˆitem_1;
-        const ˆresult_3 = x + y;
-        yield ˆresult_3;
+        const ˆresult_2 = x + y;
+        yield ˆresult_2;
       }
     }
 
@@ -127,15 +127,15 @@ exports[`map compiles single line with destructured list 1`] = `
 `;
 
 exports[`map compiles single line with destructured obj 1`] = `
-"(function map(ˆitems_2) {
+"(function map(ˆitems_3) {
   return {
     *[Symbol.iterator]() {
-      for (const ˆitem_1 of ˆitems_2) {
+      for (const ˆitem_1 of ˆitems_3) {
         const {
           \\"item\\": item
         } = ˆitem_1;
-        const ˆresult_3 = item * 2;
-        yield ˆresult_3;
+        const ˆresult_2 = item * 2;
+        yield ˆresult_2;
       }
     }
 
@@ -144,19 +144,19 @@ exports[`map compiles single line with destructured obj 1`] = `
 `;
 
 exports[`map compiles with acc 1`] = `
-"(function map(ˆitems_3) {
+"(function map(ˆitems_5) {
   return {
     *[Symbol.iterator]() {
       let ˆaccu_2 = 0;
 
-      for (const ˆitem_1 of ˆitems_3) {
+      for (const ˆitem_1 of ˆitems_5) {
         const {
           \\"foo\\": foo
         } = ˆitem_1;
         const acc = ˆaccu_2;
-        const ˆresult_4 = foo + acc;
-        yield ˆresult_4;
-        ˆaccu_2 = acc + 1;
+        const [ˆresult_3, ˆnext_accu_4] = [foo + acc, acc + 1];
+        ˆaccu_2 = ˆnext_accu_4;
+        yield ˆresult_3;
       }
     }
 
@@ -165,19 +165,19 @@ exports[`map compiles with acc 1`] = `
 `;
 
 exports[`map compiles with acc 2`] = `
-"(function map(ˆitems_3) {
+"(function map(ˆitems_5) {
   return {
     *[Symbol.iterator]() {
       let ˆaccu_2 = 0;
 
-      for (const ˆitem_1 of ˆitems_3) {
+      for (const ˆitem_1 of ˆitems_5) {
         const {
           \\"foo\\": foo
         } = ˆitem_1;
         const acc = ˆaccu_2;
-        const ˆresult_4 = [acc, foo];
-        yield* ˆresult_4;
-        ˆaccu_2 = acc + 1;
+        const [ˆresult_3, ˆnext_accu_4] = [[acc, foo], acc + 1];
+        ˆaccu_2 = ˆnext_accu_4;
+        yield* ˆresult_3;
       }
     }
 
@@ -186,28 +186,28 @@ exports[`map compiles with acc 2`] = `
 `;
 
 exports[`map compiles with foo 1`] = `
-"(function map(ˆitems_2) {
+"(function map(ˆitems_5) {
   return {
     *[Symbol.iterator]() {
-      for (const ˆitem_1 of ˆitems_2) {
+      for (const ˆitem_1 of ˆitems_5) {
         const {
           \\"foo\\": foo
         } = ˆitem_1;
 
         let _do_result;
 
-        ˆmatch_5: {
-          const ˆvalue_4 = foo;
+        ˆmatch_4: {
+          const ˆvalue_3 = foo;
 
-          if (ˆvalue_4 === bar) {
+          if (ˆvalue_3 === bar) {
             _do_result = spam;
-            break ˆmatch_5;
+            break ˆmatch_4;
           }
         }
 
-        const ˆresult_3 = _do_result;
+        const ˆresult_2 = _do_result;
         _do_result = undefined;
-        yield ˆresult_3;
+        yield ˆresult_2;
       }
     }
 

--- a/src/lang/iterable/unfold.fnk
+++ b/src/lang/iterable/unfold.fnk
@@ -1,13 +1,9 @@
 babel_types = import '@babel/types'
 {whileStatement, blockStatement} = babel_types
-{is_empty} = import '@fink/std-lib/iter.fnk'
 
+{yields, assign, generator, true_, lets, ident} = import '../../js/types.fnk'
 
-{assign, generator, true_, lets, ident, unique_ident} = import '../../js/types.fnk'
-
-{exprs_block} = import '../block/init.fnk'
-{transform_init, yield_expr} = import './common.fnk'
-{transform} = import '../transform.fnk'
+{get_iter_helpers} = import './common.fnk'
 
 
 
@@ -18,63 +14,27 @@ loop = fn ...body:
 
 
 
-get_acc_exprs = fn node, next_value, ctx:
-  [initial, acc_ctx] = unique_ident 'initial', ctx
-  [acc, acc_init_ctx] = unique_ident 'accu', acc_ctx
-  [acc_arg] = node.args;
-
-  [acc_left, acc_right, init_ctx] = match acc_arg:
-    {type: 'assign'}:
-      [right, next_ctx] = transform acc_arg.right, acc_init_ctx
-      [acc_arg.left, right, next_ctx]
-    else:
-      [acc_arg, initial, acc_init_ctx]
-
-  acc_init = lets acc, acc_right
-
-  [acc_assign, next_ctx] = transform_init acc_left, acc, init_ctx
-
-  acc_result = assign acc, next_value
-  [[initial], [acc_init], [acc_assign], [acc_result], next_ctx]
-
-
-
-get_accs = fn node, next_value, ctx:
-  match node.args:
-    is_empty ?:
-      [[], [], [], [], ctx]
-    else:
-      get_acc_exprs node, next_value, ctx
-
-
-
-get_result = fn result_id, expr,  ctx:
-  match expr:
-    {type: 'group'}:
-      [result_expr, acc_expr] = expr.exprs
-      [result_expr, ...transform acc_expr, ctx]
-    else:
-      [expr, result_id, ctx]
-
-
-
 transform_unfold = fn node, ctx:
-  [...expressions, last_expr] = node.exprs
-  [result_id, result_ctx] = unique_ident 'result', ctx
+  {
+    acc_init
+    item, items
+    item_acc_assign
+    expressions
+    result, result_is_spread
+    next_ctx
+  } = get_iter_helpers node, ctx, 'initial'
 
-  [result_expr, next_accu, acc_ctx] = get_result result_id, last_expr, result_ctx
-  [initial, acc_init, acc_assign, acc_result, block_ctx] = get_accs node, next_accu, acc_ctx
+  name = ident 'unfold', ctx
 
-  name = ident 'unfold', block_ctx
-  [body, yield_ctx] = exprs_block expressions, block_ctx
-  [yield_result, end_ctx] = yield_expr result_id, result_expr, yield_ctx
-
-  js = generator name, [...initial],
+  js = generator name, [items],
     ...acc_init
-    loop
-      ...acc_assign
-      ...body
-      ...yield_result
-      ...acc_result
+    lets item, items
 
-  [js, end_ctx]
+    loop
+      ...item_acc_assign
+      ...expressions
+      yields result, result_is_spread
+      assign item, result
+
+  [js, next_ctx]
+

--- a/src/lang/iterable/unfold.test.fnk
+++ b/src/lang/iterable/unfold.test.fnk
@@ -4,36 +4,34 @@
 
 describe 'unfold', fn:
 
-  it 'compiles item is accu', fn:
+  it 'compiles with previous', fn:
     expect
       fink2js '
-        unfold prev=0:
+        unfold prev:
           prev + 1
       '
       to_match_snapshot
 
 
-  it 'compiles with separate item and accu result', fn:
+  it 'compiles with default', fn:
     expect
       fink2js '
-        unfold {prev=0, acc=0}={}:
-          item = prev + accu
-          (item, {prev: item, accu: accu + 1})
+        unfold prev=1:
+          prev + 1
       '
       to_match_snapshot
 
 
-  it 'compiles without default assignment', fn:
+  it 'compiles with default and accu', fn:
     expect
       fink2js '
-        pipe 0:
-          unfold prev:
-            prev + 1
+        unfold prev=1, acc=1:
+          [prev * accu, accu + 1]
       '
       to_match_snapshot
 
 
-  it 'compiles without accus', fn:
+  it 'compiles without args', fn:
     expect
       fink2js '
         unfold:
@@ -51,25 +49,4 @@ describe 'unfold', fn:
       to_match_snapshot
 
 
-  it 'compiles destructured accus', fn:
-    expect
-      fink2js '
-        unfold [foo, ...bar]:
-          (foo, bar)
-      '
-      to_match_snapshot
-
-    expect
-      fink2js '
-        unfold [...foo, bar]:
-          (bar, foo)
-      '
-      to_match_snapshot
-
-    expect
-      fink2js '
-        unfold [foo, ...bar]:
-          (...foo, bar)
-      '
-      to_match_snapshot
 

--- a/src/lang/iterable/unfold.test.fnk.snap
+++ b/src/lang/iterable/unfold.test.fnk.snap
@@ -1,16 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`unfold compiles destructured accus 1`] = `
-"(function unfold(ˆinitial_2) {
+exports[`unfold compiles with default 1`] = `
+"(function unfold(ˆinitial_3) {
   return {
     *[Symbol.iterator]() {
-      let ˆaccu_3 = ˆinitial_2;
+      let ˆitem_1 = ˆinitial_3;
 
       while (true) {
-        const [foo, ...bar] = ˆaccu_3;
-        const ˆresult_1 = foo;
-        yield ˆresult_1;
-        ˆaccu_3 = bar;
+        const prev = ˆitem_1 === undefined ? 1 : ˆitem_1;
+        const ˆresult_2 = prev + 1;
+        yield ˆresult_2;
+        ˆitem_1 = ˆresult_2;
       }
     }
 
@@ -18,24 +18,20 @@ exports[`unfold compiles destructured accus 1`] = `
 });"
 `;
 
-exports[`unfold compiles destructured accus 2`] = `
-"(function unfold(ˆinitial_2) {
+exports[`unfold compiles with default and accu 1`] = `
+"(function unfold(ˆinitial_5) {
   return {
     *[Symbol.iterator]() {
-      let ˆaccu_3 = ˆinitial_2;
+      let ˆaccu_2 = 1;
+      let ˆitem_1 = ˆinitial_5;
 
       while (true) {
-        let _do_result;
-
-        {
-          const [...ˆitems_4] = ˆaccu_3;
-          _do_result = [ˆitems_4.slice(0, -1), ˆitems_4.slice(-1)];
-        }
-        const [foo, [bar]] = _do_result;
-        _do_result = undefined;
-        const ˆresult_1 = bar;
-        yield ˆresult_1;
-        ˆaccu_3 = foo;
+        const prev = ˆitem_1 === undefined ? 1 : ˆitem_1;
+        const acc = ˆaccu_2;
+        const [ˆresult_3, ˆnext_accu_4] = [prev * accu, accu + 1];
+        ˆaccu_2 = ˆnext_accu_4;
+        yield ˆresult_3;
+        ˆitem_1 = ˆresult_3;
       }
     }
 
@@ -43,60 +39,17 @@ exports[`unfold compiles destructured accus 2`] = `
 });"
 `;
 
-exports[`unfold compiles destructured accus 3`] = `
-"(function unfold(ˆinitial_2) {
+exports[`unfold compiles with previous 1`] = `
+"(function unfold(ˆinitial_3) {
   return {
     *[Symbol.iterator]() {
-      let ˆaccu_3 = ˆinitial_2;
+      let ˆitem_1 = ˆinitial_3;
 
       while (true) {
-        const [foo, ...bar] = ˆaccu_3;
-        const ˆresult_1 = foo;
-        yield* ˆresult_1;
-        ˆaccu_3 = bar;
-      }
-    }
-
-  };
-});"
-`;
-
-exports[`unfold compiles item is accu 1`] = `
-"(function unfold(ˆinitial_2) {
-  return {
-    *[Symbol.iterator]() {
-      let ˆaccu_3 = 0;
-
-      while (true) {
-        const prev = ˆaccu_3;
-        const ˆresult_1 = prev + 1;
-        yield ˆresult_1;
-        ˆaccu_3 = ˆresult_1;
-      }
-    }
-
-  };
-});"
-`;
-
-exports[`unfold compiles with separate item and accu result 1`] = `
-"(function unfold(ˆinitial_2) {
-  return {
-    *[Symbol.iterator]() {
-      let ˆaccu_3 = {};
-
-      while (true) {
-        const {
-          \\"prev\\": prev = 0,
-          \\"acc\\": acc = 0
-        } = ˆaccu_3;
-        const item = prev + accu;
-        const ˆresult_1 = item;
-        yield ˆresult_1;
-        ˆaccu_3 = {
-          \\"prev\\": item,
-          \\"accu\\": accu + 1
-        };
+        const prev = ˆitem_1;
+        const ˆresult_2 = prev + 1;
+        yield ˆresult_2;
+        ˆitem_1 = ˆresult_2;
       }
     }
 
@@ -105,12 +58,15 @@ exports[`unfold compiles with separate item and accu result 1`] = `
 `;
 
 exports[`unfold compiles with spread 1`] = `
-"(function unfold() {
+"(function unfold(ˆinitial_3) {
   return {
     *[Symbol.iterator]() {
+      let ˆitem_1 = ˆinitial_3;
+
       while (true) {
-        const ˆresult_1 = [1, 2, 3];
-        yield* ˆresult_1;
+        const ˆresult_2 = [1, 2, 3];
+        yield* ˆresult_2;
+        ˆitem_1 = ˆresult_2;
       }
     }
 
@@ -118,38 +74,19 @@ exports[`unfold compiles with spread 1`] = `
 });"
 `;
 
-exports[`unfold compiles without accus 1`] = `
-"(function unfold() {
+exports[`unfold compiles without args 1`] = `
+"(function unfold(ˆinitial_3) {
   return {
     *[Symbol.iterator]() {
+      let ˆitem_1 = ˆinitial_3;
+
       while (true) {
-        const ˆresult_1 = 1234;
-        yield ˆresult_1;
+        const ˆresult_2 = 1234;
+        yield ˆresult_2;
+        ˆitem_1 = ˆresult_2;
       }
     }
 
   };
 });"
-`;
-
-exports[`unfold compiles without default assignment 1`] = `
-"{
-  let ˆpipe_result_1 = 0;
-
-  ˆpipe_result_1 = function unfold(ˆinitial_3) {
-    return {
-      *[Symbol.iterator]() {
-        let ˆaccu_4 = ˆinitial_3;
-
-        while (true) {
-          const prev = ˆaccu_4;
-          const ˆresult_2 = prev + 1;
-          yield ˆresult_2;
-          ˆaccu_4 = ˆresult_2;
-        }
-      }
-
-    };
-  }(ˆpipe_result_1);
-}"
 `;

--- a/src/lang/iterable/until.fnk
+++ b/src/lang/iterable/until.fnk
@@ -14,7 +14,6 @@ transform_until = fn node, ctx:
     item_acc_assign
     expressions
     result
-    next_accu
     next_ctx
   } = get_iter_helpers node, ctx
 
@@ -34,7 +33,5 @@ transform_until = fn node, ctx:
       ifStatement
         eq result, true_ _
         returnStatement _
-
-      ...next_accu
 
   [js, next_ctx]

--- a/src/lang/iterable/until.test.fnk
+++ b/src/lang/iterable/until.test.fnk
@@ -16,10 +16,10 @@ describe 'until', fn:
     expect
       fink2js '
         until _, cntr=0:
-          (cntr > 2, cntr + 1)
+          [cntr > 2, cntr + 1]
 
         until , cntr=0:
-          (cntr > 2, cntr + 1)
+          [cntr > 2, cntr + 1]
       '
       to_match_snapshot
 

--- a/src/lang/iterable/until.test.fnk.snap
+++ b/src/lang/iterable/until.test.fnk.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`until compiles 1`] = `
-"(function filter_until(ˆitems_2) {
+"(function filter_until(ˆitems_3) {
   return {
     *[Symbol.iterator]() {
-      for (const ˆitem_1 of ˆitems_2) {
+      for (const ˆitem_1 of ˆitems_3) {
         yield ˆitem_1;
         const item = ˆitem_1;
-        const ˆresult_3 = item < 10;
-        if (ˆresult_3 === true) return;
+        const ˆresult_2 = item < 10;
+        if (ˆresult_2 === true) return;
       }
     }
 
@@ -17,25 +17,25 @@ exports[`until compiles 1`] = `
 `;
 
 exports[`until compiles destructuring 1`] = `
-"(function filter_until(ˆitems_2) {
+"(function filter_until(ˆitems_3) {
   return {
     *[Symbol.iterator]() {
-      for (const ˆitem_1 of ˆitems_2) {
+      for (const ˆitem_1 of ˆitems_3) {
         yield ˆitem_1;
         const [foo, ...bar] = ˆitem_1;
         const foo_alone = foo && is_empty(bar);
-        const ˆresult_3 = foo_alone;
-        if (ˆresult_3 === true) return;
+        const ˆresult_2 = foo_alone;
+        if (ˆresult_2 === true) return;
       }
     }
 
   };
 });
 
-(function filter_until(ˆitems_6) {
+(function filter_until(ˆitems_7) {
   return {
     *[Symbol.iterator]() {
-      for (const ˆitem_4 of ˆitems_6) {
+      for (const ˆitem_4 of ˆitems_7) {
         yield ˆitem_4;
 
         let _do_result;
@@ -46,8 +46,8 @@ exports[`until compiles destructuring 1`] = `
         }
         const [foo, [bar]] = _do_result;
         _do_result = undefined;
-        const ˆresult_7 = bar && is_empty(foo);
-        if (ˆresult_7 === true) return;
+        const ˆresult_6 = bar && is_empty(foo);
+        if (ˆresult_6 === true) return;
       }
     }
 
@@ -56,34 +56,34 @@ exports[`until compiles destructuring 1`] = `
 `;
 
 exports[`until compiles with accu 1`] = `
-"(function filter_until(ˆitems_3) {
+"(function filter_until(ˆitems_5) {
   return {
     *[Symbol.iterator]() {
       let ˆaccu_2 = 0;
 
-      for (const ˆitem_1 of ˆitems_3) {
+      for (const ˆitem_1 of ˆitems_5) {
         yield ˆitem_1;
         const cntr = ˆaccu_2;
-        const ˆresult_4 = cntr > 2;
-        if (ˆresult_4 === true) return;
-        ˆaccu_2 = cntr + 1;
+        const [ˆresult_3, ˆnext_accu_4] = [cntr > 2, cntr + 1];
+        ˆaccu_2 = ˆnext_accu_4;
+        if (ˆresult_3 === true) return;
       }
     }
 
   };
 });
 
-(function filter_until(ˆitems_7) {
+(function filter_until(ˆitems_10) {
   return {
     *[Symbol.iterator]() {
-      let ˆaccu_6 = 0;
+      let ˆaccu_7 = 0;
 
-      for (const ˆitem_5 of ˆitems_7) {
-        yield ˆitem_5;
-        const cntr = ˆaccu_6;
-        const ˆresult_8 = cntr > 2;
+      for (const ˆitem_6 of ˆitems_10) {
+        yield ˆitem_6;
+        const cntr = ˆaccu_7;
+        const [ˆresult_8, ˆnext_accu_9] = [cntr > 2, cntr + 1];
+        ˆaccu_7 = ˆnext_accu_9;
         if (ˆresult_8 === true) return;
-        ˆaccu_6 = cntr + 1;
       }
     }
 
@@ -92,14 +92,14 @@ exports[`until compiles with accu 1`] = `
 `;
 
 exports[`while async compiles 1`] = `
-"(function filter_until(ˆitems_2) {
+"(function filter_until(ˆitems_3) {
   return {
     async *[Symbol.asyncIterator]() {
-      for await (const ˆitem_1 of ˆitems_2) {
+      for await (const ˆitem_1 of ˆitems_3) {
         yield ˆitem_1;
         const item = ˆitem_1;
-        const ˆresult_3 = (await item) < 10;
-        if (ˆresult_3 === true) return;
+        const ˆresult_2 = (await item) < 10;
+        if (ˆresult_2 === true) return;
       }
     }
 

--- a/src/lang/iterable/while.fnk
+++ b/src/lang/iterable/while.fnk
@@ -14,7 +14,6 @@ transform_while = fn node, ctx:
     item_acc_assign
     expressions
     result
-    next_accu
     next_ctx
   } = get_iter_helpers node, ctx
 
@@ -33,7 +32,5 @@ transform_while = fn node, ctx:
         returnStatement _
 
       yields item
-
-      ...next_accu
 
   [js, next_ctx]

--- a/src/lang/iterable/while.test.fnk
+++ b/src/lang/iterable/while.test.fnk
@@ -16,13 +16,13 @@ describe 'while', fn:
     expect
       fink2js '
         while _, cntr=0:
-          (cntr < 2, cntr + 1)
+          [cntr < 2, cntr + 1]
 
         while , cntr=0:
-          (cntr < 2, cntr + 1)
+          [cntr < 2, cntr + 1]
 
         while item, cntr=0:
-          (item and cntr < 2, cntr + 1)
+          [item and cntr < 2, cntr + 1]
       '
       to_match_snapshot
 

--- a/src/lang/iterable/while.test.fnk.snap
+++ b/src/lang/iterable/while.test.fnk.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`while async compiles 1`] = `
-"(function filter_while(ˆitems_2) {
+"(function filter_while(ˆitems_3) {
   return {
     async *[Symbol.asyncIterator]() {
-      for await (const ˆitem_1 of ˆitems_2) {
+      for await (const ˆitem_1 of ˆitems_3) {
         const item = ˆitem_1;
-        const ˆresult_3 = (await item) < 10;
-        if (ˆresult_3 !== true) return;
+        const ˆresult_2 = (await item) < 10;
+        if (ˆresult_2 !== true) return;
         yield ˆitem_1;
       }
     }
@@ -17,13 +17,13 @@ exports[`while async compiles 1`] = `
 `;
 
 exports[`while compiles 1`] = `
-"(function filter_while(ˆitems_2) {
+"(function filter_while(ˆitems_3) {
   return {
     *[Symbol.iterator]() {
-      for (const ˆitem_1 of ˆitems_2) {
+      for (const ˆitem_1 of ˆitems_3) {
         const item = ˆitem_1;
-        const ˆresult_3 = item < 10;
-        if (ˆresult_3 !== true) return;
+        const ˆresult_2 = item < 10;
+        if (ˆresult_2 !== true) return;
         yield ˆitem_1;
       }
     }
@@ -33,55 +33,15 @@ exports[`while compiles 1`] = `
 `;
 
 exports[`while compiles destructuring 1`] = `
-"(function filter_while(ˆitems_2) {
-  return {
-    *[Symbol.iterator]() {
-      for (const ˆitem_1 of ˆitems_2) {
-        const [foo, ...bar] = ˆitem_1;
-        const foo_alone = foo && is_empty(bar);
-        const ˆresult_3 = foo_alone;
-        if (ˆresult_3 !== true) return;
-        yield ˆitem_1;
-      }
-    }
-
-  };
-});
-
-(function filter_while(ˆitems_6) {
-  return {
-    *[Symbol.iterator]() {
-      for (const ˆitem_4 of ˆitems_6) {
-        let _do_result;
-
-        {
-          const [...ˆitems_5] = ˆitem_4;
-          _do_result = [ˆitems_5.slice(0, -1), ˆitems_5.slice(-1)];
-        }
-        const [foo, [bar]] = _do_result;
-        _do_result = undefined;
-        const ˆresult_7 = bar && is_empty(foo);
-        if (ˆresult_7 !== true) return;
-        yield ˆitem_4;
-      }
-    }
-
-  };
-});"
-`;
-
-exports[`while compiles with accu 1`] = `
 "(function filter_while(ˆitems_3) {
   return {
     *[Symbol.iterator]() {
-      let ˆaccu_2 = 0;
-
       for (const ˆitem_1 of ˆitems_3) {
-        const cntr = ˆaccu_2;
-        const ˆresult_4 = cntr < 2;
-        if (ˆresult_4 !== true) return;
+        const [foo, ...bar] = ˆitem_1;
+        const foo_alone = foo && is_empty(bar);
+        const ˆresult_2 = foo_alone;
+        if (ˆresult_2 !== true) return;
         yield ˆitem_1;
-        ˆaccu_2 = cntr + 1;
       }
     }
 
@@ -91,32 +51,72 @@ exports[`while compiles with accu 1`] = `
 (function filter_while(ˆitems_7) {
   return {
     *[Symbol.iterator]() {
-      let ˆaccu_6 = 0;
+      for (const ˆitem_4 of ˆitems_7) {
+        let _do_result;
 
-      for (const ˆitem_5 of ˆitems_7) {
-        const cntr = ˆaccu_6;
-        const ˆresult_8 = cntr < 2;
-        if (ˆresult_8 !== true) return;
-        yield ˆitem_5;
-        ˆaccu_6 = cntr + 1;
+        {
+          const [...ˆitems_5] = ˆitem_4;
+          _do_result = [ˆitems_5.slice(0, -1), ˆitems_5.slice(-1)];
+        }
+        const [foo, [bar]] = _do_result;
+        _do_result = undefined;
+        const ˆresult_6 = bar && is_empty(foo);
+        if (ˆresult_6 !== true) return;
+        yield ˆitem_4;
+      }
+    }
+
+  };
+});"
+`;
+
+exports[`while compiles with accu 1`] = `
+"(function filter_while(ˆitems_5) {
+  return {
+    *[Symbol.iterator]() {
+      let ˆaccu_2 = 0;
+
+      for (const ˆitem_1 of ˆitems_5) {
+        const cntr = ˆaccu_2;
+        const [ˆresult_3, ˆnext_accu_4] = [cntr < 2, cntr + 1];
+        ˆaccu_2 = ˆnext_accu_4;
+        if (ˆresult_3 !== true) return;
+        yield ˆitem_1;
       }
     }
 
   };
 });
 
-(function filter_while(ˆitems_11) {
+(function filter_while(ˆitems_10) {
   return {
     *[Symbol.iterator]() {
-      let ˆaccu_10 = 0;
+      let ˆaccu_7 = 0;
 
-      for (const ˆitem_9 of ˆitems_11) {
-        const item = ˆitem_9;
-        const cntr = ˆaccu_10;
-        const ˆresult_12 = item && cntr < 2;
-        if (ˆresult_12 !== true) return;
-        yield ˆitem_9;
-        ˆaccu_10 = cntr + 1;
+      for (const ˆitem_6 of ˆitems_10) {
+        const cntr = ˆaccu_7;
+        const [ˆresult_8, ˆnext_accu_9] = [cntr < 2, cntr + 1];
+        ˆaccu_7 = ˆnext_accu_9;
+        if (ˆresult_8 !== true) return;
+        yield ˆitem_6;
+      }
+    }
+
+  };
+});
+
+(function filter_while(ˆitems_15) {
+  return {
+    *[Symbol.iterator]() {
+      let ˆaccu_12 = 0;
+
+      for (const ˆitem_11 of ˆitems_15) {
+        const item = ˆitem_11;
+        const cntr = ˆaccu_12;
+        const [ˆresult_13, ˆnext_accu_14] = [item && cntr < 2, cntr + 1];
+        ˆaccu_12 = ˆnext_accu_14;
+        if (ˆresult_13 !== true) return;
+        yield ˆitem_11;
       }
     }
 


### PR DESCRIPTION
All iterable blocks now support an optional accu arg.
If provided the result is treated as `[result, next_accu]` tuple.

The `fold` block now up to three args `item, prev_result, accu`
to be more consistent with the rest.

The `unfold` block has up to two args  `prev_result, accu`
to be consistent with the rest of the iterables.

BREAKING CHANGE: fold, unfold changed args semantics for accu handling
removed support for `(result, next_accu)` syntax in favour of using new accu handling